### PR TITLE
G2B-8 로컬·서버 특정품목 CSV E2E 검증 완료

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,7 @@ out/
 .vscode/
 *.hprof
 backend/sheet/*.json
+
+### G2B 로컬 파일 ###
+docs/sample_csv/
+*.docx

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,100 @@
+# G2BPlatform — Claude Code 컨텍스트
+
+## 프로젝트 개요
+
+| 항목 | 내용 |
+|------|------|
+| 경로 | `/Users/junfe/Desktop/G2B/G2BPlatform` |
+| Backend | Java 21, Spring Boot 3.3, WebFlux, JPA, MyBatis, Flyway, Security(JWT) |
+| Frontend | Vue 3, Vite 6, Axios |
+| DB | 로컬: MySQL 8 (`root@127.0.0.1`, 스키마 `g2b`) / 서버: RDS MySQL 8.4 (`admin@g2b-db-prod.c7so4iqo4f0a.ap-northeast-2.rds.amazonaws.com`) |
+| 배포 | Docker Compose (`g2b-api-1`:8080 + `g2b-web-1`:3000), 서버 nginx `deploy/g2b.conf` |
+| 서버 | `ssh -i ~/Desktop/G2B/ssh/g2b_prod.pem ubuntu@3.37.169.101` (경로: `~/g2b`) |
+| 도메인 | https://g2btop.duckdns.org |
+
+---
+
+## Git 규칙
+
+- Jira 프로젝트: **G2B**
+- 브랜치: `feature/{JIRA_KEY}-{slug}` (master에서 분기)
+- 커밋: `{JIRA_KEY} {type}: 한 줄 요약`
+- **커밋·푸시·PR·서버 배포는 명시적 요청 시에만 실행**
+- `application.properties`, service key 등 비밀값 커밋 절대 금지
+  - `backend/.gitignore`에 `application.properties` 등록되어 있음
+  - 서버 `application.properties`는 서버에만 존재, git 이력에서 완전 제거 완료 (2026-06-09)
+
+---
+
+## 로드맵 현황
+
+| Phase | 내용 | 상태 |
+|-------|------|------|
+| Phase 1 | G2B-8 로컬 특정품목 CSV E2E 검증 | ✅ 완료 |
+| Phase 2 | 서버 배포 + Flyway V8~V10 검증 | ✅ 완료 |
+| Phase 3 | 서버 실제 CSV 대량 업로드·검증 (문서화) | 🔄 진행 중 |
+| Phase 4 | 업무별 구성원별 CSV 분석·설계 문서 | ⏳ 대기 (Phase 3 완료 후) |
+| Phase 5 | Flyway V11 raw 테이블 | ⏳ 대기 |
+| Phase 6 | 백엔드 task-member-contract 업로드 API | ⏳ 대기 |
+| Phase 7 | 프론트 두 번째 탭 연동 | ⏳ 대기 |
+| Phase 8 | 서버 반영·운영 적재 | ⏳ 대기 |
+
+> **Phase 3 끝나기 전에 Phase 4 시작 금지**
+
+---
+
+## 현재 브랜치
+
+- `feature/G2B-8-local-specific-item-e2e` — Phase 1~2 작업 브랜치 (push 완료)
+
+---
+
+## 주요 결정사항 (ADR 요약)
+
+### DB 연결
+- 로컬 직접 기동(Gradle) 시: `application-local.properties`의 `spring.datasource.url=jdbc:mysql://127.0.0.1:3306/g2b...` 사용
+- 로컬 Docker Compose 기동 시: `host.docker.internal:3306` → 호스트 MySQL 연결
+- 서버: RDS `g2b-db-prod` (admin 계정, 비밀번호는 서버 `~/g2b/backend/src/main/resources/application.properties`에만 존재)
+
+### Flyway
+- 서버 RDS에 Flyway 최초 도입 시 `flyway_schema_history` 수동 baseline 삽입으로 해결 (V7 baseline)
+- `baselineOnMigrate=true` 코드 추가 방식은 채택하지 않음 (빈 DB 배포 시 위험)
+
+### 특정품목 CSV 업로드 (구현 완료)
+- API: `POST /api/admin/upload/specific-item`
+- 권한: `ROLE_SUPER_ADMIN`
+- 처리: UTF-16→UTF-8 변환, JDBC batch 2000건, `INSERT IGNORE`
+- 로컬 적재 결과: 2017~2026년 **1,023,477행** (Job 14건 전부 SUCCESS)
+- 중복 방지: 재업로드 시 전량 skipped 확인
+
+### 보안 조치 (2026-06-09)
+- `application.properties`가 과거 커밋에 포함된 사실 발견 (RDS 비밀번호 `g2btop123` 노출)
+- RDS 비밀번호 교체 완료
+- `git filter-repo`로 전체 이력에서 파일 제거 후 force push 완료
+- GitHub Support 캐시 제거 요청은 선택사항 (비밀번호 교체로 실질 위험 없음)
+
+---
+
+## 핵심 참고 파일
+
+| 영역 | 경로 |
+|------|------|
+| ADR (특정품목 Job) | `docs/adr/ADR-0001-specific-item-raw-ingestion-job.md` |
+| CSV·ETL 계획 | `docs/plan_csv_upload_etl_migration.md` |
+| 로컬 E2E 런북 | `docs/runbook/local-specific-item-upload.md` |
+| 샘플 CSV | `docs/sample_csv/` |
+| raw 테이블 DDL | `backend/src/main/resources/db/migration/V8~V10` |
+| 업로드 API | `backend/.../controller/CsvUploadController.java` |
+| Job 서비스 | `backend/.../service/SpecificItemCsvJobService.java` |
+| 업로드 UI | `frontend/src/views/RawDataImportView.vue` |
+| 비동기 풀 | `backend/.../config/AsyncConfig.java` (pool=2) |
+| 로컬 스케줄 off | `backend/src/main/resources/application-local.properties` |
+
+---
+
+## 미구현 (향후 작업)
+
+- raw → flat/grouped ETL (`CALL sp_etl_*`) — 별도 티켓
+- Job 취소 API — 미구현 (api restart 시 Job 중단)
+- `SpecificItemCsvService.java` — 레거시, 사용 안 함
+- RawDataImport 두 번째 탭 **업무별 구성원별 계약내역** — UI 스텁만 존재 (Phase 4~7)

--- a/backend/src/main/resources/application-local.properties
+++ b/backend/src/main/resources/application-local.properties
@@ -1,2 +1,3 @@
 # 로컬 실행 시 스케줄러 비활성화 (서버에서만 돌리려면 이 프로파일 사용)
 app.scheduling.enabled=false
+spring.datasource.url=jdbc:mysql://127.0.0.1:3306/g2b?useSSL=false&serverTimezone=UTC&allowPublicKeyRetrieval=true

--- a/docs/runbook/local-specific-item-upload.md
+++ b/docs/runbook/local-specific-item-upload.md
@@ -1,0 +1,180 @@
+# 로컬 특정품목 CSV 업로드 E2E 검증 런북
+
+**티켓:** G2B-8  
+**검증일:** 2026-06-09  
+**검증자:** super_admin  
+**결과:** 전체 PASS
+
+---
+
+## 1. 사전 조건
+
+| 항목 | 확인 방법 | 기댓값 |
+|------|-----------|--------|
+| 로컬 MySQL | `mysql -u root g2b -e "SELECT 1;"` | 정상 응답 |
+| Flyway V8~V10 | `SELECT version, success FROM flyway_schema_history;` | 전부 success=1 |
+| 테이블 존재 | `SHOW TABLES LIKE 'procurement_specific_item_raw';` 등 | 3개 테이블 확인 |
+| Docker Compose | `docker ps` | `g2bplatform-api-1` (8080), `g2bplatform-web-1` (3000) UP |
+
+### Flyway 마이그레이션 확인 쿼리
+
+```sql
+SELECT version, description, success
+FROM flyway_schema_history
+ORDER BY installed_rank;
+```
+
+**실행 결과 (2026-06-09):**
+
+| version | description | success |
+|---------|-------------|---------|
+| 7 | baseline_before_specific_item_raw | 1 |
+| 8 | create specific item raw | 1 |
+| 9 | create csv upload history | 1 |
+| 10 | create csv upload job | 1 |
+
+---
+
+## 2. 앱 기동
+
+로컬 Docker Compose 환경은 `host.docker.internal:3306`(호스트 MySQL)에 연결된다.
+
+```bash
+# 프로젝트 루트에서
+docker compose up -d
+```
+
+- 백엔드: `http://localhost:8080`
+- 프론트: `http://localhost:3000`
+
+> **주의:** `docker-compose.yml`은 `application.properties`를 마운트한다.  
+> `spring.datasource.url`이 `host.docker.internal:3306`이면 로컬 MySQL 연결.  
+> `rds.amazonaws.com`이면 프로덕션 DB — 반드시 확인 후 기동.
+
+---
+
+## 3. SUPER_ADMIN 로그인
+
+```bash
+curl -s -X POST http://localhost:8080/api/auth/login \
+  -H "Content-Type: application/json" \
+  -d '{"username":"super_admin","password":"<비밀번호>"}'
+```
+
+응답에서 `accessToken` 추출 후 이후 요청에 사용.
+
+---
+
+## 4. CSV 업로드
+
+**대상 파일:** `docs/sample_csv/2026_특정품목 조달 내역.csv`  
+**파일 크기:** 약 15 MB  
+**인코딩:** UTF-16 (서비스 내부에서 UTF-8 변환 처리)
+
+```bash
+TOKEN="<accessToken>"
+
+curl -s -X POST http://localhost:8080/api/admin/upload/specific-item \
+  -H "Authorization: Bearer $TOKEN" \
+  -F "file=@docs/sample_csv/2026_특정품목 조달 내역.csv"
+```
+
+응답 예시:
+```json
+{
+  "jobId": "4a2f3958-7c1b-426f-960d-3a661ba8c493",
+  "status": "QUEUED",
+  "totalRows": null,
+  "processedRows": 0
+}
+```
+
+---
+
+## 5. Job 폴링
+
+```bash
+JOB_ID="<jobId>"
+
+curl -s "http://localhost:8080/api/admin/upload/jobs/$JOB_ID" \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+`status`가 `SUCCESS` 또는 `FAILED`가 될 때까지 반복 확인 (약 10초 간격).
+
+---
+
+## 6. 검증 쿼리
+
+```sql
+-- raw 테이블 적재 건수
+SELECT COUNT(*) AS total FROM procurement_specific_item_raw;
+
+-- 소스 파일별 건수
+SELECT source_file, COUNT(*) AS cnt
+FROM procurement_specific_item_raw
+GROUP BY source_file;
+
+-- Job 결과 확인
+SELECT id, status, inserted_count, skipped_count, total_rows, started_at, finished_at
+FROM csv_upload_job
+ORDER BY started_at DESC
+LIMIT 5;
+```
+
+---
+
+## 7. 검증 결과 (2026-06-09)
+
+### 샘플 파일 업로드 (2026, curl)
+
+| 항목 | 값 |
+|------|----|
+| jobId | 4a2f3958-7c1b-426f-960d-3a661ba8c493 |
+| status | SUCCESS |
+| totalRows | 16,592 |
+| insertedCount | 16,592 |
+| skippedCount | 0 |
+| 소요 시간 | 약 25초 (15:50:36 → 15:51:01) |
+
+### 재업로드 (중복 방지 확인)
+
+| 항목 | 값 |
+|------|----|
+| jobId | 403a9df4-1d2d-4e02-8dab-c055bcb7a829 |
+| status | SUCCESS |
+| totalRows | 16,592 |
+| insertedCount | 0 |
+| skippedCount | 16,592 |
+| 소요 시간 | 약 25초 |
+
+`INSERT IGNORE` 동작 정상 확인 — 중복 행 전량 skip.
+
+### 전체 연도 적재 (2017~2026, UI 업로드)
+
+| 연도 | 적재 건수 |
+|------|----------|
+| 2017 | 77,544 |
+| 2018 | 83,920 |
+| 2019 | 95,841 |
+| 2020 | 106,678 |
+| 2021 | 121,620 |
+| 2022 | 121,576 |
+| 2023 | 139,782 |
+| 2024 | 141,026 |
+| 2025 | 118,898 |
+| 2026 | 16,592 |
+| **합계** | **1,023,477** |
+
+- Job 14건 전부 SUCCESS
+- `procurement_specific_item_raw` 총 1,023,477행 확인
+
+---
+
+## 8. 블로커 및 수정 이력
+
+| 항목 | 내용 | 조치 |
+|------|------|------|
+| `application-local.properties` 오타 | 파일 끝 `ㅊ` 문자 제거 | 삭제 |
+| 로컬 직접 기동 시 DB 연결 실패 | `./gradlew bootRun` 시 `host.docker.internal` 미해석 | `application-local.properties`에 `spring.datasource.url=jdbc:mysql://127.0.0.1:3306/g2b...` 추가 (Docker 외부 기동 시 사용) |
+| Docker Compose 사용 시 정상 | `host.docker.internal`은 컨테이너 내부에서 호스트 MySQL로 정상 해석됨 | Docker Compose로 기동 확정 |


### PR DESCRIPTION
## Jira 티켓
G2B-8 — 로컬 DB·Flyway·특정품목 CSV 적재 E2E 검증 (Epic: E1 특정품목 로컬 검증)

## 작업 내용

### Phase 1 — 로컬 E2E 검증
- Flyway V8~V10 마이그레이션 정상 적용 확인 (`procurement_specific_item_raw`, `csv_upload_job`, `csv_upload_history`)
- 로컬 Docker Compose 기동 (`host.docker.internal:3306` → 로컬 MySQL 연결)
- SUPER_ADMIN 로그인 → `/raw-data-import` CSV 업로드 검증
  - 최초 업로드: 2017~2026년 전체 **1,023,477행** 적재, Job 14건 전부 SUCCESS
  - 재업로드: 16,592행 전량 skipped (INSERT IGNORE 정상 동작 확인)
- `application-local.properties` — IDE 직접 기동 시 `127.0.0.1` datasource URL 추가

### Phase 2 — 서버 배포 + Flyway 검증
- 서버 `docker compose up --build -d` 완료
- 서버 RDS Flyway 최초 도입 — baseline(V7) 수동 삽입 후 V8~V10 자동 적용 완료
- RDS 비밀번호 변경 후 `allowPublicKeyRetrieval=true` 추가로 연결 복구

### 보안 조치
- 과거 커밋에 포함된 `application.properties` (RDS 비밀번호 포함) 발견
- RDS 비밀번호 교체 완료
- `git filter-repo`로 전체 이력에서 파일 제거 후 force push 완료

### 산출물
- `docs/runbook/local-specific-item-upload.md` — 기동 명령·검증 쿼리·전체 결과 문서화
- `CLAUDE.md` — 프로젝트 컨텍스트 (로드맵·결정사항·참고 파일 정리)

## 테스트 방법
1. `docker compose up -d` 후 `http://localhost:3000/raw-data-import` 접속
2. SUPER_ADMIN 로그인 → CSV 업로드 → Job SUCCESS 확인
3. 동일 파일 재업로드 → skipped 카운트 확인
4. `SELECT COUNT(*) FROM procurement_specific_item_raw;` → 1,023,477 확인

## 변경 파일
- `backend/src/main/resources/application-local.properties` — datasource URL 추가
- `docs/runbook/local-specific-item-upload.md` — 신규
- `CLAUDE.md` — 신규

🤖 Generated with [Claude Code](https://claude.com/claude-code)