### PR TITLE
Feature/g2 b 11 task member contract analysis

### DIFF
--- a/backend/src/main/java/org/example/g2bplatform/controller/CsvUploadController.java
+++ b/backend/src/main/java/org/example/g2bplatform/controller/CsvUploadController.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.example.g2bplatform.DTO.CsvUploadJobDto;
 import org.example.g2bplatform.service.SpecificItemCsvJobService;
+import org.example.g2bplatform.service.TaskMemberContractCsvJobService;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -19,6 +20,7 @@ import org.springframework.web.multipart.MultipartFile;
 public class CsvUploadController {
 
     private final SpecificItemCsvJobService specificItemCsvJobService;
+    private final TaskMemberContractCsvJobService taskMemberContractCsvJobService;
 
     /**
      * 특정품목 조달 내역 CSV 업로드 → 비동기 적재 Job 생성.
@@ -42,6 +44,30 @@ public class CsvUploadController {
 
         String uploader = (auth == null) ? null : auth.getName();
         CsvUploadJobDto job = specificItemCsvJobService.startSpecificItemJob(file, uploader);
+
+        if ("FAILED".equals(job.getStatus())) return ResponseEntity.unprocessableEntity().body(job);
+
+        return ResponseEntity.ok(job);
+    }
+
+    @Operation(summary = "업무별 구성원별 계약내역 CSV 적재(Job 시작)",
+               description = "기술용역/공사 CSV를 업로드하면 비동기 적재 Job을 생성하고 jobId를 반환합니다. " +
+                             "파일명에 '공사' 포함 시 construction, 나머지는 engineering으로 자동 분류됩니다.")
+    @PreAuthorize("hasRole('SUPER_ADMIN')")
+    @PostMapping(value = "/task-member-contract", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<CsvUploadJobDto> uploadTaskMemberContract(
+            @RequestParam("file") MultipartFile file,
+            Authentication auth) {
+
+        if (file == null || file.isEmpty()) {
+            return ResponseEntity.badRequest().body(CsvUploadJobDto.builder()
+                    .status("FAILED")
+                    .errorMessage("파일이 첨부되지 않았습니다.")
+                    .build());
+        }
+
+        String uploader = (auth == null) ? null : auth.getName();
+        CsvUploadJobDto job = taskMemberContractCsvJobService.startJob(file, uploader);
 
         if ("FAILED".equals(job.getStatus())) return ResponseEntity.unprocessableEntity().body(job);
 

--- a/backend/src/main/java/org/example/g2bplatform/controller/CsvUploadController.java
+++ b/backend/src/main/java/org/example/g2bplatform/controller/CsvUploadController.java
@@ -80,6 +80,7 @@ public class CsvUploadController {
     @GetMapping("/jobs/{jobId}")
     public ResponseEntity<CsvUploadJobDto> getJob(@PathVariable String jobId) {
         CsvUploadJobDto job = specificItemCsvJobService.getJob(jobId);
+        if (job == null) job = taskMemberContractCsvJobService.getJob(jobId);
         if (job == null) return ResponseEntity.notFound().build();
         return ResponseEntity.ok(job);
     }

--- a/backend/src/main/java/org/example/g2bplatform/service/TaskMemberContractCsvJobService.java
+++ b/backend/src/main/java/org/example/g2bplatform/service/TaskMemberContractCsvJobService.java
@@ -1,0 +1,315 @@
+package org.example.g2bplatform.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.g2bplatform.DTO.CsvUploadJobDto;
+import org.example.g2bplatform.DTO.CsvUploadResultDto;
+import org.springframework.core.task.TaskExecutor;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.*;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.util.*;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class TaskMemberContractCsvJobService {
+
+    private static final int BATCH_SIZE = 2_000;
+
+    private static final String INSERT_SQL =
+            "INSERT IGNORE INTO task_member_contract_raw (" +
+                    "  contract_type," +
+                    "  procurement_method, contract_no, change_seq, is_final_contract," +
+                    "  contract_date, first_contract_date, contract_name," +
+                    "  demand_agency_code, demand_agency_name," +
+                    "  contract_method, bid_notice_no, bid_notice_seq, bid_method, applicable_law, clause_content," +
+                    "  new_long_term_type, is_long_term_first_year, first_year_contract_no, long_term_sequence," +
+                    "  public_procurement_type, public_procurement_major, public_procurement_minor," +
+                    "  work_location, start_date, end_date, total_end_date," +
+                    "  vendor_enterprise_type, vendor_region," +
+                    "  is_female_enterprise, is_disabled_enterprise, is_social_enterprise," +
+                    "  jurisdiction_type, demand_agency_region, joint_contract_method, work_type," +
+                    "  is_representative, vendor_name, vendor_biz_reg_no, representative_name," +
+                    "  contract_share_rate_raw, contract_share_change_raw, contract_share_amount_raw," +
+                    "  current_contract_amount_raw, first_contract_amount_raw, total_contract_amount_raw," +
+                    "  source_file" +
+                    ") VALUES (" +
+                    "  ?," +
+                    "  ?,?,?,?," +
+                    "  ?,?,?," +
+                    "  ?,?," +
+                    "  ?,?,?,?,?,?," +
+                    "  ?,?,?,?," +
+                    "  ?,?,?," +
+                    "  ?,?,?,?," +
+                    "  ?,?," +
+                    "  ?,?,?," +
+                    "  ?,?,?,?," +
+                    "  ?,?,?,?," +
+                    "  ?,?,?," +
+                    "  ?,?,?," +
+                    "  ?" +
+                    ")";
+
+    private final JdbcTemplate jdbc;
+    private final TaskExecutor csvJobExecutor;
+
+    public CsvUploadJobDto startJob(MultipartFile file, String uploader) {
+        String jobId = UUID.randomUUID().toString();
+        String fileName = file.getOriginalFilename() == null ? "" : file.getOriginalFilename();
+        long fileSizeBytes = file.getSize();
+        String contractType = detectContractType(fileName);
+
+        try {
+            File dir = new File("/tmp/g2b-upload");
+            dir.mkdirs();
+            String tempPath = new File(dir, jobId + ".csv").getAbsolutePath();
+
+            try (BufferedReader reader = openReaderUtf16(file);
+                 BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(tempPath), StandardCharsets.UTF_8))) {
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    writer.write(line);
+                    writer.newLine();
+                }
+            }
+
+            jdbc.update(
+                    "INSERT INTO csv_upload_job (id, upload_type, file_name, file_size_bytes, temp_path, status, message, uploader, created_at, updated_at) " +
+                            "VALUES (?,?,?,?,?,?,?,?,NOW(),NOW())",
+                    jobId, "task_member_contract", fileName, fileSizeBytes, tempPath, "QUEUED", "대기 중", uploader
+            );
+
+            csvJobExecutor.execute(() -> runJob(jobId, tempPath, fileName, fileSizeBytes, contractType, uploader));
+
+            return CsvUploadJobDto.builder()
+                    .jobId(jobId)
+                    .uploadType("task_member_contract")
+                    .fileName(fileName)
+                    .fileSizeBytes(fileSizeBytes)
+                    .status("QUEUED")
+                    .message("대기 중")
+                    .processedRows(0)
+                    .insertedCount(0)
+                    .skippedCount(0)
+                    .build();
+
+        } catch (Exception e) {
+            log.error("Job 시작 실패: {}", fileName, e);
+            return CsvUploadJobDto.builder()
+                    .jobId(jobId)
+                    .uploadType("task_member_contract")
+                    .fileName(fileName)
+                    .fileSizeBytes(fileSizeBytes)
+                    .status("FAILED")
+                    .errorMessage(e.getMessage())
+                    .build();
+        }
+    }
+
+    public CsvUploadJobDto getJob(String jobId) {
+        List<CsvUploadJobDto> list = jdbc.query(
+                "SELECT id, upload_type, file_name, file_size_bytes, status, message, total_rows, processed_rows, inserted_count, skipped_count, started_at, finished_at, error_message " +
+                        "FROM csv_upload_job WHERE id = ?",
+                (rs, rowNum) -> CsvUploadJobDto.builder()
+                        .jobId(rs.getString("id"))
+                        .uploadType(rs.getString("upload_type"))
+                        .fileName(rs.getString("file_name"))
+                        .fileSizeBytes((Long) rs.getObject("file_size_bytes"))
+                        .status(rs.getString("status"))
+                        .message(rs.getString("message"))
+                        .totalRows((Integer) rs.getObject("total_rows"))
+                        .processedRows(rs.getInt("processed_rows"))
+                        .insertedCount(rs.getInt("inserted_count"))
+                        .skippedCount(rs.getInt("skipped_count"))
+                        .startedAt(rs.getObject("started_at", LocalDateTime.class))
+                        .finishedAt(rs.getObject("finished_at", LocalDateTime.class))
+                        .errorMessage(rs.getString("error_message"))
+                        .build(),
+                jobId
+        );
+        return list.isEmpty() ? null : list.get(0);
+    }
+
+    // 파일명으로 업종 자동 판별
+    private String detectContractType(String fileName) {
+        if (fileName == null) return "engineering";
+        if (fileName.contains("공사")) return "construction";
+        return "engineering";
+    }
+
+    private void runJob(String jobId, String tempPath, String fileName, long fileSizeBytes, String contractType, String uploader) {
+        try {
+            jdbc.update("UPDATE csv_upload_job SET status='RUNNING', message='총 행 수 계산 중', started_at=NOW() WHERE id=?", jobId);
+            int totalRows = countTotalRows(tempPath);
+            jdbc.update("UPDATE csv_upload_job SET total_rows=?, message='적재 중' WHERE id=?", totalRows, jobId);
+
+            CsvUploadResultDto result = loadAndInsert(jobId, tempPath, fileName, fileSizeBytes, contractType, uploader, totalRows);
+            String finalStatus = (result.getErrorMessage() == null) ? "SUCCESS" : "FAILED";
+
+            jdbc.update(
+                    "UPDATE csv_upload_job SET status=?, message=?, finished_at=NOW(), error_message=? WHERE id=?",
+                    finalStatus,
+                    (result.getErrorMessage() == null) ? "완료" : "실패",
+                    result.getErrorMessage(),
+                    jobId
+            );
+        } catch (Exception e) {
+            log.error("Job 실패: {}", jobId, e);
+            jdbc.update(
+                    "UPDATE csv_upload_job SET status='FAILED', message='실패', finished_at=NOW(), error_message=? WHERE id=?",
+                    e.getMessage(), jobId
+            );
+        } finally {
+            try { new File(tempPath).delete(); } catch (Exception ignore) {}
+        }
+    }
+
+    private int countTotalRows(String tempPath) throws Exception {
+        int total = 0;
+        boolean headerFound = false;
+        try (BufferedReader reader = openTempReader(tempPath)) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                if (!headerFound) {
+                    if (line.contains("조달방식") && line.contains("계약번호")) { headerFound = true; }
+                    continue;
+                }
+                if (splitLine(line).length < 45) continue;
+                total++;
+            }
+        }
+        return total;
+    }
+
+    private CsvUploadResultDto loadAndInsert(String jobId, String tempPath, String fileName, long fileSizeBytes, String contractType, String uploader, int totalRows) {
+        long start = System.currentTimeMillis();
+        List<Object[]> batch = new ArrayList<>(BATCH_SIZE);
+        int processed = 0, inserted = 0;
+        boolean headerFound = false;
+
+        try (BufferedReader reader = openTempReader(tempPath)) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                if (!headerFound) {
+                    if (line.contains("조달방식") && line.contains("계약번호")) { headerFound = true; }
+                    continue;
+                }
+                String[] cols = splitLine(line);
+                if (cols.length < 45) continue;
+
+                processed++;
+                batch.add(toParams(cols, contractType, fileName));
+
+                if (batch.size() >= BATCH_SIZE) {
+                    inserted += executeBatch(batch);
+                    batch.clear();
+                    jdbc.update("UPDATE csv_upload_job SET processed_rows=?, inserted_count=?, skipped_count=?, message='적재 중' WHERE id=?",
+                            processed, inserted, processed - inserted, jobId);
+                }
+            }
+            if (!batch.isEmpty()) inserted += executeBatch(batch);
+
+            jdbc.update("UPDATE csv_upload_job SET processed_rows=?, inserted_count=?, skipped_count=?, message='마무리 중' WHERE id=?",
+                    processed, inserted, processed - inserted, jobId);
+
+            if (!headerFound) {
+                CsvUploadResultDto err = CsvUploadResultDto.error(fileName, "헤더 행을 찾을 수 없습니다. 올바른 업무별 구성원별 계약내역 CSV 파일인지 확인하세요.");
+                err.setFileSizeBytes(fileSizeBytes);
+                err.setTotalRows(totalRows);
+                err.setInsertedCount(inserted);
+                err.setSkippedCount(processed - inserted);
+                err.setElapsedMs(System.currentTimeMillis() - start);
+                writeUploadHistory(fileName, fileSizeBytes, uploader, err);
+                return err;
+            }
+
+            long elapsed = System.currentTimeMillis() - start;
+            CsvUploadResultDto ok = CsvUploadResultDto.builder()
+                    .fileName(fileName)
+                    .fileSizeBytes(fileSizeBytes)
+                    .totalRows(totalRows)
+                    .insertedCount(inserted)
+                    .skippedCount(processed - inserted)
+                    .elapsedMs(elapsed)
+                    .build();
+            writeUploadHistory(fileName, fileSizeBytes, uploader, ok);
+            return ok;
+
+        } catch (Exception e) {
+            CsvUploadResultDto err = CsvUploadResultDto.error(fileName, e.getMessage());
+            err.setFileSizeBytes(fileSizeBytes);
+            err.setTotalRows(totalRows);
+            err.setInsertedCount(inserted);
+            err.setSkippedCount(processed - inserted);
+            err.setElapsedMs(System.currentTimeMillis() - start);
+            writeUploadHistory(fileName, fileSizeBytes, uploader, err);
+            return err;
+        }
+    }
+
+    private Object[] toParams(String[] c, String contractType, String fileName) {
+        return new Object[]{
+                contractType,
+                n(c[0]),  n(c[1]),  n(c[2]),  flag(c[3]),
+                n(c[4]),  n(c[5]),  n(c[6]),
+                n(c[7]),  n(c[8]),
+                n(c[9]),  n(c[10]), n(c[11]), n(c[12]), n(c[13]), n(c[14]),
+                n(c[15]), flag(c[16]), n(c[17]), n(c[18]),
+                n(c[19]), n(c[20]), n(c[21]),
+                n(c[22]), n(c[23]), n(c[24]), n(c[25]),
+                n(c[26]), n(c[27]),
+                flag(c[28]), flag(c[29]), flag(c[30]),
+                n(c[31]), n(c[32]), n(c[33]), n(c[34]),
+                flag(c[35]), n(c[36]), n(c[37]), n(c[38]),
+                n(c[39]), n(c[40]), n(c[41]),
+                n(c[42]), n(c[43]), n(c[44]),
+                fileName
+        };
+    }
+
+    private String[] splitLine(String line) {
+        String[] parts = line.split("\t", -1);
+        for (int i = 0; i < parts.length; i++) {
+            String v = parts[i].trim();
+            if (v.startsWith("\"") && v.endsWith("\"") && v.length() >= 2) v = v.substring(1, v.length() - 1);
+            parts[i] = v;
+        }
+        return parts;
+    }
+
+    private String n(String v) { return (v == null || v.isEmpty()) ? null : v; }
+    private String flag(String v) { return (v == null || v.isEmpty()) ? null : v.toUpperCase(); }
+
+    private int executeBatch(List<Object[]> batch) {
+        int[] results = jdbc.batchUpdate(INSERT_SQL, batch);
+        int count = 0;
+        for (int r : results) if (r > 0) count += r;
+        return count;
+    }
+
+    private BufferedReader openTempReader(String tempPath) throws Exception {
+        return new BufferedReader(new InputStreamReader(new FileInputStream(tempPath), StandardCharsets.UTF_8));
+    }
+
+    private BufferedReader openReaderUtf16(MultipartFile file) throws Exception {
+        return new BufferedReader(new InputStreamReader(file.getInputStream(), Charset.forName("UTF-16")));
+    }
+
+    private void writeUploadHistory(String fileName, long fileSizeBytes, String uploader, CsvUploadResultDto result) {
+        String status = (result.getErrorMessage() == null) ? "SUCCESS" : "FAILED";
+        jdbc.update(
+                "INSERT INTO csv_upload_history (upload_type, file_name, file_size_bytes, total_rows, inserted_count, skipped_count, elapsed_ms, uploader, status, error_message) " +
+                        "VALUES (?,?,?,?,?,?,?,?,?,?)",
+                "task_member_contract", fileName == null ? "" : fileName,
+                fileSizeBytes, result.getTotalRows(), result.getInsertedCount(),
+                result.getSkippedCount(), result.getElapsedMs(), uploader, status, result.getErrorMessage()
+        );
+    }
+}

--- a/backend/src/main/java/org/example/g2bplatform/service/TaskMemberContractCsvJobService.java
+++ b/backend/src/main/java/org/example/g2bplatform/service/TaskMemberContractCsvJobService.java
@@ -139,9 +139,9 @@ public class TaskMemberContractCsvJobService {
 
     // 파일명으로 업종 자동 판별
     private String detectContractType(String fileName) {
-        if (fileName == null) return "engineering";
+        if (fileName == null) return "service";
         if (fileName.contains("공사")) return "construction";
-        return "engineering";
+        return "service";
     }
 
     private void runJob(String jobId, String tempPath, String fileName, long fileSizeBytes, String contractType, String uploader) {
@@ -275,13 +275,37 @@ public class TaskMemberContractCsvJobService {
     }
 
     private String[] splitLine(String line) {
-        String[] parts = line.split("\t", -1);
-        for (int i = 0; i < parts.length; i++) {
-            String v = parts[i].trim();
-            if (v.startsWith("\"") && v.endsWith("\"") && v.length() >= 2) v = v.substring(1, v.length() - 1);
-            parts[i] = v;
+        // RFC 4180 CSV 파서: 쌍따옴표로 감싼 필드 내 쉼표를 구분자로 오인하지 않도록 처리
+        List<String> fields = new ArrayList<>();
+        StringBuilder cur = new StringBuilder();
+        boolean inQuote = false;
+        for (int i = 0; i < line.length(); i++) {
+            char c = line.charAt(i);
+            if (inQuote) {
+                if (c == '"') {
+                    // escaped quote ""
+                    if (i + 1 < line.length() && line.charAt(i + 1) == '"') {
+                        cur.append('"');
+                        i++;
+                    } else {
+                        inQuote = false;
+                    }
+                } else {
+                    cur.append(c);
+                }
+            } else {
+                if (c == '"') {
+                    inQuote = true;
+                } else if (c == ',') {
+                    fields.add(cur.toString().trim());
+                    cur.setLength(0);
+                } else {
+                    cur.append(c);
+                }
+            }
         }
-        return parts;
+        fields.add(cur.toString().trim());
+        return fields.toArray(new String[0]);
     }
 
     private String n(String v) { return (v == null || v.isEmpty()) ? null : v; }

--- a/backend/src/main/resources/db/migration/V11__create_task_member_contract_raw.sql
+++ b/backend/src/main/resources/db/migration/V11__create_task_member_contract_raw.sql
@@ -1,0 +1,84 @@
+-- 업무별 구성원별 계약내역 RAW 테이블
+-- 조달데이터허브 '업무별 구성원별 계약내역' CSV를 원본 그대로 적재.
+-- 기술용역(engineering)과 공사(construction) 데이터를 단일 테이블에 저장하며,
+-- contract_type 컬럼으로 구분. 날짜 컬럼(착수/완수)은 명칭이 다르나 의미가 동일하여 통합.
+CREATE TABLE IF NOT EXISTS task_member_contract_raw (
+    id                          BIGINT          NOT NULL AUTO_INCREMENT PRIMARY KEY,
+
+    -- 업종 구분
+    contract_type               VARCHAR(20)     NOT NULL COMMENT '업종구분: service(기술용역) | construction(공사)',
+
+    -- 조달/계약 분류 (원본 CSV 1~4열)
+    procurement_method          VARCHAR(20)     NOT NULL DEFAULT '' COMMENT '조달방식',
+    contract_no                 VARCHAR(30)     NOT NULL COMMENT '계약번호',
+    change_seq                  VARCHAR(5)      NOT NULL DEFAULT '' COMMENT '계약변경차수',
+    is_final_contract           CHAR(1)                  DEFAULT NULL COMMENT '최종계약여부 Y/N',
+
+    -- 계약 기본 정보 (원본 CSV 5~9열)
+    contract_date               CHAR(8)                  DEFAULT NULL COMMENT '계약일자 YYYYMMDD',
+    first_contract_date         CHAR(8)                  DEFAULT NULL COMMENT '최초계약일자 YYYYMMDD',
+    contract_name               VARCHAR(500)             DEFAULT NULL COMMENT '계약명',
+    demand_agency_code          VARCHAR(20)              DEFAULT NULL COMMENT '수요기관코드',
+    demand_agency_name          VARCHAR(200)             DEFAULT NULL COMMENT '수요기관',
+
+    -- 입찰/낙찰 정보 (원본 CSV 10~15열)
+    contract_method             VARCHAR(20)              DEFAULT NULL COMMENT '계약방법',
+    bid_notice_no               VARCHAR(30)              DEFAULT NULL COMMENT '입찰공고번호',
+    bid_notice_seq              VARCHAR(5)               DEFAULT NULL COMMENT '입찰공고차수',
+    bid_method                  VARCHAR(50)              DEFAULT NULL COMMENT '낙찰방법',
+    applicable_law              VARCHAR(20)              DEFAULT NULL COMMENT '적용계약법',
+    clause_content              VARCHAR(200)             DEFAULT NULL COMMENT '조항호내용',
+
+    -- 장기계약 정보 (원본 CSV 16~19열)
+    new_long_term_type          VARCHAR(50)              DEFAULT NULL COMMENT '신규장기구분',
+    is_long_term_first_year     CHAR(1)                  DEFAULT NULL COMMENT '장기초년도계약여부 Y/N',
+    first_year_contract_no      VARCHAR(30)              DEFAULT NULL COMMENT '초년도계약번호',
+    long_term_sequence          VARCHAR(5)               DEFAULT NULL COMMENT '장기계속차수',
+
+    -- 공공조달 분류 (원본 CSV 20~22열)
+    public_procurement_type     VARCHAR(30)              DEFAULT NULL COMMENT '공공조달분류',
+    public_procurement_major    VARCHAR(50)              DEFAULT NULL COMMENT '공공조달대분류',
+    public_procurement_minor    VARCHAR(50)              DEFAULT NULL COMMENT '공공조달중분류',
+
+    -- 현장/일정 정보 (원본 CSV 23~26열)
+    work_location               VARCHAR(100)             DEFAULT NULL COMMENT '공사현장(기술용역)/공사현장(공사)',
+    start_date                  CHAR(8)                  DEFAULT NULL COMMENT '착수일자(기술용역) / 착공일자(공사) YYYYMMDD',
+    end_date                    CHAR(8)                  DEFAULT NULL COMMENT '완수일자(기술용역) / 준공일자(공사) YYYYMMDD',
+    total_end_date              CHAR(8)                  DEFAULT NULL COMMENT '총완수일자(기술용역) / 총준공일자(공사) YYYYMMDD',
+
+    -- 업체 정보 (원본 CSV 27~39열)
+    vendor_enterprise_type      VARCHAR(30)              DEFAULT NULL COMMENT '계약시점 기업구분',
+    vendor_region               VARCHAR(100)             DEFAULT NULL COMMENT '계약시점 업체소재시군구',
+    is_female_enterprise        CHAR(1)                  DEFAULT NULL COMMENT '계약시점 여성기업인증여부 Y/N',
+    is_disabled_enterprise      CHAR(1)                  DEFAULT NULL COMMENT '계약시점 장애인기업인증여부 Y/N',
+    is_social_enterprise        CHAR(1)                  DEFAULT NULL COMMENT '계약시점 사회적기업인증여부 Y/N',
+    jurisdiction_type           VARCHAR(30)              DEFAULT NULL COMMENT '소관구분',
+    demand_agency_region        VARCHAR(100)             DEFAULT NULL COMMENT '수요기관소재시군구',
+    joint_contract_method       VARCHAR(30)              DEFAULT NULL COMMENT '공동도급방식',
+    work_type                   VARCHAR(50)              DEFAULT NULL COMMENT '공종',
+    is_representative           CHAR(1)                  DEFAULT NULL COMMENT '대표업체여부 Y/N',
+    vendor_name                 VARCHAR(200)             DEFAULT NULL COMMENT '업체명',
+    vendor_biz_reg_no           VARCHAR(15)              DEFAULT NULL COMMENT '사업자등록번호',
+    representative_name         VARCHAR(50)              DEFAULT NULL COMMENT '대표자명',
+
+    -- 금액 정보 (원본 CSV 40~45열, 쉼표 포함 원본 보존)
+    contract_share_rate_raw     VARCHAR(20)              DEFAULT NULL COMMENT '계약지분율 (원본)',
+    contract_share_change_raw   VARCHAR(30)              DEFAULT NULL COMMENT '계약지분증감금액 (원본)',
+    contract_share_amount_raw   VARCHAR(30)              DEFAULT NULL COMMENT '계약지분금액 (원본)',
+    current_contract_amount_raw VARCHAR(30)              DEFAULT NULL COMMENT '금차계약금액 (원본)',
+    first_contract_amount_raw   VARCHAR(30)              DEFAULT NULL COMMENT '최초계약금액 (원본)',
+    total_contract_amount_raw   VARCHAR(30)              DEFAULT NULL COMMENT '총계약금액 (원본)',
+
+    -- 시스템 메타
+    source_file                 VARCHAR(200)             DEFAULT NULL COMMENT '업로드 원본 파일명',
+    created_at                  DATETIME        NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    UNIQUE KEY uq_task_member_contract   (contract_no, change_seq, contract_type),
+    INDEX      idx_contract_date         (contract_date),
+    INDEX      idx_first_contract_date   (first_contract_date),
+    INDEX      idx_contract_type         (contract_type),
+    INDEX      idx_vendor_biz_reg_no     (vendor_biz_reg_no),
+    INDEX      idx_is_final_contract     (is_final_contract),
+    INDEX      idx_demand_agency_code    (demand_agency_code)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+  COMMENT='업무별 구성원별 계약내역 RAW 테이블 (기술용역+공사 통합, 조달데이터허브)';

--- a/docs/adr/ADR-0002-task-member-contract-raw-ingestion.md
+++ b/docs/adr/ADR-0002-task-member-contract-raw-ingestion.md
@@ -15,7 +15,7 @@
 
 **기술용역과 공사를 단일 테이블 `task_member_contract_raw`로 통합 적재한다.**
 
-- **결정 내용**: `contract_type` 컬럼(engineering | construction)으로 업종 구분. 날짜 컬럼은 `start_date`, `end_date`, `total_end_date`로 통합
+- **결정 내용**: `contract_type` 컬럼(service | construction)으로 업종 구분. 날짜 컬럼은 `start_date`, `end_date`, `total_end_date`로 통합
 - **적용 범위**: V11 Flyway 마이그레이션, 업로드 API `POST /api/admin/upload/task-member-contract`, 프론트 업로드 탭 단일화
 - **롤아웃**: 기존 `service_contract_raw`, `construction_contract_raw` DROP → `task_member_contract_raw` 신규 생성 → CSV 재적재
 

--- a/docs/adr/ADR-0002-task-member-contract-raw-ingestion.md
+++ b/docs/adr/ADR-0002-task-member-contract-raw-ingestion.md
@@ -1,0 +1,49 @@
+# ADR-0002: 업무별 구성원별 계약내역 RAW 적재 전략
+
+- **Status**: Accepted
+- **Date**: 2026-06-11
+- **Owners**: JunFe23
+
+## Context
+
+- 조달데이터허브에서 '업무별 구성원별 계약내역'을 기술용역/공사 두 종류로 CSV 다운로드 가능
+- 기존에 `service_contract_raw`, `construction_contract_raw` 두 테이블이 존재했으나, CSV 구조 변경으로 재설계 필요
+- 두 CSV의 컬럼 구조를 분석한 결과 45개 중 42개 공통, 3개만 명칭 차이(착수/완수일자 ↔ 착공/준공일자)
+- 향후 flat/grouped/summary 테이블과 대시보드 구현이 목표
+
+## Decision
+
+**기술용역과 공사를 단일 테이블 `task_member_contract_raw`로 통합 적재한다.**
+
+- **결정 내용**: `contract_type` 컬럼(engineering | construction)으로 업종 구분. 날짜 컬럼은 `start_date`, `end_date`, `total_end_date`로 통합
+- **적용 범위**: V11 Flyway 마이그레이션, 업로드 API `POST /api/admin/upload/task-member-contract`, 프론트 업로드 탭 단일화
+- **롤아웃**: 기존 `service_contract_raw`, `construction_contract_raw` DROP → `task_member_contract_raw` 신규 생성 → CSV 재적재
+
+## Consequences
+
+### Positive
+
+- 테이블 하나로 관리 → 조회/ETL 쿼리 단순화
+- 업로드 UI 탭 하나로 통합 → UX 단순화
+- 향후 flat/grouped 테이블 설계 시 UNION 없이 단일 소스 테이블 사용
+
+### Negative / Risks
+
+- `contract_type` 필터를 빠뜨리면 기술용역+공사가 혼합 집계될 수 있음 → 조회 쿼리 작성 시 주의 필요
+- 기존 `service_contract_flat`, `service_contract_grouped`, `construction_contract_flat`, `construction_contract_grouped`는 구 raw 테이블 기반 → ETL 재설계 필요 (Phase 이후 별도 티켓)
+
+### Operational notes
+
+- 업로드 시 파일명에 '기술용역' 포함 여부로 `contract_type` 자동 판별 (fallback: 드롭다운 선택)
+- 중복 방지: `UNIQUE KEY (contract_no, change_seq, contract_type)`
+
+## Alternatives considered
+
+- **대안 A — 테이블 2개 유지** (`service_contract_raw`, `construction_contract_raw`): 컬럼 차이가 3개뿐이라 중복 관리 비용이 더 큼. 기각
+- **대안 B — contract_type 없이 파일명으로만 구분**: 조회 시 매번 source_file 패턴 매칭 필요, 인덱스 활용 어려움. 기각
+
+## Links
+
+- Issue: G2B-11
+- Migration: `backend/src/main/resources/db/migration/V11__create_task_member_contract_raw.sql`
+- Sample CSV: `docs/sample_csv/task_member_contract/`

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -3,7 +3,7 @@ server {
     server_name localhost;
 
     # 업로드(대용량 CSV) 허용. (기본값은 너무 작아 413 발생)
-    client_max_body_size 150m;
+    client_max_body_size 500m;
 
     root /usr/share/nginx/html;
     index index.html;

--- a/frontend/src/views/RawDataImportView.vue
+++ b/frontend/src/views/RawDataImportView.vue
@@ -116,22 +116,99 @@
         </div>
       </section>
 
-      <!-- 업무별 구성원별 계약내역 탭 (추후 구현) -->
+      <!-- 업무별 구성원별 계약내역 탭 -->
       <section v-if="activeTab === 'task'" class="section">
         <h2 class="section-title">업무별 구성원별 계약내역 CSV 적재</h2>
-        <div class="upload-zone">
-          <input type="file" accept=".csv,.xlsx" class="file-input" disabled />
+        <p class="tab-desc">
+          조달데이터허브 &gt; 업무별 구성원별 계약내역 CSV (UTF-16, 탭 구분).<br>
+          파일명에 <strong>공사</strong>가 포함되면 공사(construction), 그 외는 기술용역(engineering)으로 자동 분류됩니다.
+        </p>
+
+        <div
+          class="upload-zone"
+          :class="{ dragging: taskIsDragging }"
+          @dragover.prevent="taskIsDragging = true"
+          @dragleave.prevent="taskIsDragging = false"
+          @drop.prevent="onTaskDrop"
+        >
+          <input
+            ref="taskFileInputRef"
+            type="file"
+            accept=".csv,.tsv"
+            class="file-input"
+            @change="onTaskFileSelect"
+          />
           <div class="upload-placeholder">
             <span class="upload-icon">📄</span>
-            <p>CSV / Excel 파일을 선택하거나 여기에 끌어다 놓으세요.</p>
+            <p v-if="!taskSelectedFile">CSV 파일을 선택하거나 여기에 끌어다 놓으세요.</p>
+            <p v-else class="selected-name">{{ taskSelectedFile.name }} ({{ formatBytes(taskSelectedFile.size) }})</p>
           </div>
         </div>
-        <div class="notice-box">
-          <strong>구현 예정</strong>
-          <p>공사·용역 데이터 원천인 업무별 구성원별 계약내역 업로드 기능은 추후 구현 예정입니다.</p>
+
+        <!-- 결과 카드 -->
+        <div v-if="taskResult" class="result-card" :class="taskResult.errorMessage ? 'result-error' : 'result-ok'">
+          <template v-if="taskResult.errorMessage">
+            <p class="result-title">적재 실패</p>
+            <p class="result-msg">{{ taskResult.errorMessage }}</p>
+          </template>
+          <template v-else>
+            <p class="result-title">적재 완료</p>
+            <div class="result-grid">
+              <div class="result-item">
+                <span class="result-label">전체 행</span>
+                <span class="result-value">{{ taskResult.totalRows.toLocaleString() }}건</span>
+              </div>
+              <div class="result-item">
+                <span class="result-label">신규 적재</span>
+                <span class="result-value green">{{ taskResult.insertedCount.toLocaleString() }}건</span>
+              </div>
+              <div class="result-item">
+                <span class="result-label">중복 스킵</span>
+                <span class="result-value gray">{{ taskResult.skippedCount.toLocaleString() }}건</span>
+              </div>
+              <div class="result-item">
+                <span class="result-label">소요 시간</span>
+                <span class="result-value">{{ (taskResult.elapsedMs / 1000).toFixed(1) }}초</span>
+              </div>
+            </div>
+          </template>
         </div>
+
+        <!-- 진행률 표시 -->
+        <div v-if="taskUploading || taskActiveJobId" class="progress-card">
+          <div class="progress-head">
+            <span class="progress-title">{{ taskProgressPhaseLabel }}</span>
+            <span class="progress-pct">{{ taskProgressPct }}%</span>
+          </div>
+          <div class="progress-bar" :class="{ processing: taskProgressPhase === 'processing' }">
+            <div class="progress-fill" :style="{ width: taskProgressPct + '%' }"></div>
+          </div>
+          <p class="progress-hint">
+            <template v-if="taskProgressPhase === 'uploading'">
+              파일 업로드 중입니다. (브라우저 → 서버)
+              <span v-if="taskUploadEtaText"> · 남은시간 {{ taskUploadEtaText }}</span>
+            </template>
+            <template v-else-if="taskProgressPhase === 'processing'">
+              서버에서 CSV를 파싱하고 DB에 적재하는 중입니다.
+              <span v-if="taskServerEtaText"> · 남은시간 {{ taskServerEtaText }}</span>
+              <span v-if="taskJobMessage" class="job-msg"> · {{ taskJobMessage }}</span>
+            </template>
+            <template v-else>
+              진행 상태를 불러오는 중입니다.
+            </template>
+          </p>
+        </div>
+
         <div class="action-row">
-          <button type="button" class="btn-import" disabled>적재 시작 (구현 예정)</button>
+          <button
+            type="button"
+            class="btn-import"
+            :disabled="!taskSelectedFile || taskUploading"
+            @click="doTaskUpload"
+          >
+            <span v-if="taskUploading" class="spinner"></span>
+            {{ taskUploading ? '적재 중...' : '적재 시작' }}
+          </button>
         </div>
       </section>
     </div>
@@ -149,6 +226,8 @@ const tabs = [
 ]
 
 const activeTab   = ref('specific')
+
+// ── 특정품목 탭 상태 ──
 const selectedFile = ref(null)
 const fileInputRef = ref(null)
 const uploading   = ref(false)
@@ -164,16 +243,45 @@ const jobMessage = ref('')
 let uploadStartedAtMs = 0
 let lastProgressAtMs = 0
 let lastLoaded = 0
-let emaBps = 0 // exponential moving average bytes/sec
+let emaBps = 0
 let pollTimer = null
 let lastJobSampleAt = 0
 let lastJobProcessed = 0
-let jobRateEma = 0 // rows/sec
+let jobRateEma = 0
 
 const progressPhaseLabel = computed(() => {
   if (progressPhase.value === 'uploading') return '업로드 중'
   if (progressPhase.value === 'processing') return '적재 처리 중'
   if (activeJobId.value) return '적재 처리 중'
+  return ''
+})
+
+// ── 업무별 구성원별 계약내역 탭 상태 ──
+const taskSelectedFile = ref(null)
+const taskFileInputRef = ref(null)
+const taskUploading   = ref(false)
+const taskIsDragging  = ref(false)
+const taskResult      = ref(null)
+const taskProgressPct = ref(0)
+const taskProgressPhase = ref('idle')
+const taskUploadEtaText = ref('')
+const taskServerEtaText = ref('')
+const taskActiveJobId = ref(localStorage.getItem('taskContractJobId') || '')
+const taskJobMessage = ref('')
+
+let taskUploadStartedAtMs = 0
+let taskLastProgressAtMs = 0
+let taskLastLoaded = 0
+let taskEmaBps = 0
+let taskPollTimer = null
+let taskLastJobSampleAt = 0
+let taskLastJobProcessed = 0
+let taskJobRateEma = 0
+
+const taskProgressPhaseLabel = computed(() => {
+  if (taskProgressPhase.value === 'uploading') return '업로드 중'
+  if (taskProgressPhase.value === 'processing') return '적재 처리 중'
+  if (taskActiveJobId.value) return '적재 처리 중'
   return ''
 })
 
@@ -364,6 +472,186 @@ async function pollJob() {
   }
 }
 
+// ── 업무별 구성원별 계약내역 탭 핸들러 ──
+function onTaskFileSelect(event) {
+  const file = event.target.files?.[0]
+  if (file) setTaskFile(file)
+}
+
+function onTaskDrop(event) {
+  taskIsDragging.value = false
+  const file = event.dataTransfer.files?.[0]
+  if (file) setTaskFile(file)
+}
+
+function setTaskFile(file) {
+  taskSelectedFile.value = file
+  taskResult.value = null
+  taskProgressPct.value = 0
+  taskProgressPhase.value = 'idle'
+  taskUploadEtaText.value = ''
+  taskServerEtaText.value = ''
+  taskUploadStartedAtMs = 0
+  taskLastProgressAtMs = 0
+  taskLastLoaded = 0
+  taskEmaBps = 0
+}
+
+async function doTaskUpload() {
+  if (!taskSelectedFile.value || taskUploading.value) return
+
+  taskUploading.value = true
+  taskResult.value    = null
+  taskProgressPct.value = 0
+  taskProgressPhase.value = 'uploading'
+  taskUploadEtaText.value = ''
+  taskServerEtaText.value = ''
+  taskUploadStartedAtMs = Date.now()
+  taskLastProgressAtMs = taskUploadStartedAtMs
+  taskLastLoaded = 0
+  taskEmaBps = 0
+
+  const formData = new FormData()
+  formData.append('file', taskSelectedFile.value)
+
+  try {
+    const res = await axios.post('/api/admin/upload/task-member-contract', formData, {
+      headers: { 'Content-Type': 'multipart/form-data' },
+      timeout: 300_000,
+      onUploadProgress: (evt) => {
+        const total = evt.total ?? taskSelectedFile.value?.size ?? 0
+        if (!total) return
+
+        const now = Date.now()
+        const dt = Math.max(1, now - taskLastProgressAtMs)
+        const dLoaded = Math.max(0, evt.loaded - taskLastLoaded)
+        if (dLoaded > 0) {
+          if (dt >= 100) {
+            const bps = (dLoaded * 1000) / dt
+            taskEmaBps = taskEmaBps ? (taskEmaBps * 0.8 + bps * 0.2) : bps
+            taskLastProgressAtMs = now
+            taskLastLoaded = evt.loaded
+          }
+          const elapsed = Math.max(1, now - taskUploadStartedAtMs)
+          const avgBps = (evt.loaded * 1000) / elapsed
+          const effBps = taskEmaBps || avgBps
+          const remainingBytes = Math.max(0, total - evt.loaded)
+          if (effBps > 0 && remainingBytes > 0) {
+            taskUploadEtaText.value = formatEta(remainingBytes / effBps)
+          } else {
+            taskUploadEtaText.value = ''
+          }
+        }
+
+        if (evt.loaded >= total) {
+          taskProgressPhase.value = 'processing'
+          taskProgressPct.value = 100
+          taskUploadEtaText.value = ''
+          return
+        }
+
+        taskProgressPct.value = Math.round((evt.loaded / total) * 100)
+      },
+    })
+
+    const jobId = res.data?.jobId
+    if (jobId) {
+      taskActiveJobId.value = jobId
+      localStorage.setItem('taskContractJobId', jobId)
+      taskProgressPhase.value = 'processing'
+      taskProgressPct.value = 0
+      startTaskPolling()
+    } else {
+      taskResult.value = { errorMessage: 'jobId를 받지 못했습니다.' }
+    }
+  } catch (err) {
+    const msg = err.response?.data?.errorMessage
+      || err.response?.data?.message
+      || err.message
+      || '서버 오류가 발생했습니다.'
+    taskResult.value = { errorMessage: msg }
+  } finally {
+    taskUploading.value = false
+    if (!taskActiveJobId.value) taskProgressPhase.value = 'idle'
+  }
+}
+
+function startTaskPolling() {
+  if (!taskActiveJobId.value) return
+  stopTaskPolling()
+  taskLastJobSampleAt = Date.now()
+  taskLastJobProcessed = 0
+  taskJobRateEma = 0
+  taskPollTimer = setInterval(pollTaskJob, 1000)
+  pollTaskJob()
+}
+
+function stopTaskPolling() {
+  if (taskPollTimer) {
+    clearInterval(taskPollTimer)
+    taskPollTimer = null
+  }
+}
+
+async function pollTaskJob() {
+  if (!taskActiveJobId.value) return
+  try {
+    const res = await axios.get(`/api/admin/upload/jobs/${taskActiveJobId.value}`)
+    const job = res.data
+
+    const total = job.totalRows ?? 0
+    const processed = job.processedRows ?? 0
+    const inserted = job.insertedCount ?? 0
+    const skipped = job.skippedCount ?? 0
+    taskJobMessage.value = job.message || ''
+
+    if (total > 0) {
+      taskProgressPct.value = Math.min(100, Math.round((processed / total) * 100))
+    } else {
+      taskProgressPct.value = 0
+    }
+
+    const now = Date.now()
+    const dt = Math.max(1, (now - taskLastJobSampleAt) / 1000)
+    const dProc = Math.max(0, processed - taskLastJobProcessed)
+    const rate = dProc / dt
+    taskJobRateEma = taskJobRateEma ? (taskJobRateEma * 0.8 + rate * 0.2) : rate
+    taskLastJobSampleAt = now
+    taskLastJobProcessed = processed
+
+    if (total > 0 && taskJobRateEma > 0 && processed < total) {
+      taskServerEtaText.value = formatEta((total - processed) / taskJobRateEma)
+    } else {
+      taskServerEtaText.value = ''
+    }
+
+    if (job.status === 'SUCCESS' || job.status === 'FAILED' || job.status === 'CANCELLED') {
+      stopTaskPolling()
+      if (job.status === 'SUCCESS') {
+        taskResult.value = {
+          totalRows: total,
+          insertedCount: inserted,
+          skippedCount: skipped,
+          elapsedMs: job.finishedAt && job.startedAt
+            ? (new Date(job.finishedAt).getTime() - new Date(job.startedAt).getTime())
+            : 0,
+        }
+      } else {
+        taskResult.value = { errorMessage: job.errorMessage || '적재 실패' }
+      }
+      localStorage.removeItem('taskContractJobId')
+      taskActiveJobId.value = ''
+      taskJobMessage.value = ''
+      taskServerEtaText.value = ''
+      taskProgressPhase.value = 'idle'
+    } else {
+      taskProgressPhase.value = 'processing'
+    }
+  } catch (e) {
+    // 일시 오류 시에도 폴링 지속
+  }
+}
+
 function formatEta(sec) {
   if (!Number.isFinite(sec) || sec < 0) return ''
   const s = Math.ceil(sec)
@@ -386,6 +674,10 @@ function formatBytes(bytes) {
 if (activeJobId.value) {
   progressPhase.value = 'processing'
   startPolling()
+}
+if (taskActiveJobId.value) {
+  taskProgressPhase.value = 'processing'
+  startTaskPolling()
 }
 </script>
 


### PR DESCRIPTION
## Summary

- Flyway V11: `task_member_contract_raw` 테이블 생성 (기술용역+공사 단일 테이블, `contract_type`으로 구분)
- `TaskMemberContractCsvJobService`: 쉼표 구분 RFC4180 CSV 파서, UTF-16→UTF-8 변환, JDBC batch 2000건, INSERT IGNORE
- `CsvUploadController`: `POST /api/admin/upload/task-member-contract` 엔드포인트 추가, `getJob`에서 두 서비스 모두 조회하도록 수정
- `RawDataImportView`: 두 번째 탭 완전 구현 (파일 선택/드래그앤드롭/진행률/ETA/결과카드/새로고침 복구)
- nginx/Spring Boot 업로드 제한 150MB → 500MB 상향 (업무별 계약내역 CSV 파일이 400MB+ 수준)
- `contract_type` 값: 기술용역 → `service`, 공사 → `construction` (파일명 기반 자동 판별)

## ADR

- [ADR-0002: 업무별 구성원별 계약내역 RAW 적재 전략](docs/adr/ADR-0002-task-member-contract-raw-ingestion.md)

## Test plan

- [x] 로컬 Docker 환경에서 기술용역 CSV 업로드 → `contract_type = service` 적재 확인
- [x] 로컬 Docker 환경에서 공사 CSV 업로드 → `contract_type = construction` 적재 확인
- [ ] 재업로드 시 전량 skipped (중복 방지) 확인
- [ ] 서버 배포 후 RDS V11 마이그레이션 확인 (Phase 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)