### PR TITLE
G2B-16 feat: 장기계약 grouped 테이블 도입 및 특정품목 조회 개선

### DIFF
--- a/backend/src/main/java/org/example/g2bplatform/controller/CsvUploadController.java
+++ b/backend/src/main/java/org/example/g2bplatform/controller/CsvUploadController.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.example.g2bplatform.DTO.CsvUploadJobDto;
 import org.example.g2bplatform.service.SpecificItemCsvJobService;
+import org.example.g2bplatform.service.SpecificItemEtlService;
 import org.example.g2bplatform.service.TaskMemberContractCsvJobService;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -21,6 +22,7 @@ public class CsvUploadController {
 
     private final SpecificItemCsvJobService specificItemCsvJobService;
     private final TaskMemberContractCsvJobService taskMemberContractCsvJobService;
+    private final SpecificItemEtlService specificItemEtlService;
 
     /**
      * 특정품목 조달 내역 CSV 업로드 → 비동기 적재 Job 생성.
@@ -81,6 +83,7 @@ public class CsvUploadController {
     public ResponseEntity<CsvUploadJobDto> getJob(@PathVariable String jobId) {
         CsvUploadJobDto job = specificItemCsvJobService.getJob(jobId);
         if (job == null) job = taskMemberContractCsvJobService.getJob(jobId);
+        if (job == null) job = specificItemEtlService.getJob(jobId);
         if (job == null) return ResponseEntity.notFound().build();
         return ResponseEntity.ok(job);
     }

--- a/backend/src/main/java/org/example/g2bplatform/controller/SpecificItemController.java
+++ b/backend/src/main/java/org/example/g2bplatform/controller/SpecificItemController.java
@@ -68,10 +68,14 @@ public class SpecificItemController {
         return ResponseEntity.ok(res);
     }
 
-    /** 저장 여부 토글 */
+    /** 저장 여부 토글 — grouped 여부에 따라 대상 테이블 분기 */
     @PatchMapping("/api/specific-item/saved")
     public ResponseEntity<Void> toggleSaved(@RequestBody Map<String, Object> body) {
-        specificItemMapper.updateSaved(body);
+        if (Boolean.TRUE.equals(body.get("grouped"))) {
+            specificItemMapper.updateGroupedSaved(body);
+        } else {
+            specificItemMapper.updateSaved(body);
+        }
         return ResponseEntity.ok().build();
     }
 

--- a/backend/src/main/java/org/example/g2bplatform/controller/SpecificItemController.java
+++ b/backend/src/main/java/org/example/g2bplatform/controller/SpecificItemController.java
@@ -1,0 +1,208 @@
+package org.example.g2bplatform.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.example.g2bplatform.DTO.CsvUploadJobDto;
+import org.example.g2bplatform.mapper.SpecificItemMapper;
+import org.example.g2bplatform.service.SpecificItemEtlService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping
+@RequiredArgsConstructor
+public class SpecificItemController {
+
+    private final SpecificItemEtlService etlService;
+    private final SpecificItemMapper specificItemMapper;
+
+    /** ETL 실행 — SUPER_ADMIN 전용, 비동기 Job 반환 */
+    @PostMapping("/api/admin/etl/specific-item")
+    @PreAuthorize("hasRole('SUPER_ADMIN')")
+    public ResponseEntity<CsvUploadJobDto> runEtl(Authentication auth) {
+        String triggeredBy = (auth == null) ? null : auth.getName();
+        CsvUploadJobDto job = etlService.startEtlJob(triggeredBy);
+        return ResponseEntity.ok(job);
+    }
+
+    /** 통합 조회 */
+    @GetMapping("/api/specific-item")
+    public ResponseEntity<Map<String, Object>> list(
+            @RequestParam(required = false) String dataType,
+            @RequestParam(required = false) String demandAgencyName,
+            @RequestParam(required = false) String demandAgencyRegion,
+            @RequestParam(required = false) String vendorBizRegNo,
+            @RequestParam(required = false) String itemCategoryNo,
+            @RequestParam(required = false) String detailItemNo,
+            @RequestParam(required = false) String isMas,
+            @RequestParam(required = false) String isExcellentProduct,
+            @RequestParam(required = false) Integer year,
+            @RequestParam(required = false) String month,
+            @RequestParam(required = false) String rangeStart,
+            @RequestParam(required = false) String rangeEnd,
+            @RequestParam(required = false, defaultValue = "false") boolean showSavedOnly,
+            @RequestParam(required = false, defaultValue = "false") boolean grouped,
+            @RequestParam(defaultValue = "0") int start,
+            @RequestParam(defaultValue = "100") int length
+    ) {
+        Map<String, Object> params = buildParams(
+                dataType, demandAgencyName, demandAgencyRegion, vendorBizRegNo,
+                itemCategoryNo, detailItemNo, isMas, isExcellentProduct,
+                year, month, rangeStart, rangeEnd, showSavedOnly, grouped, start, length);
+
+        List<Map<String, Object>> data = grouped
+                ? specificItemMapper.selectGroupedList(params)
+                : specificItemMapper.selectFlatList(params);
+        int total = grouped
+                ? specificItemMapper.selectGroupedCount(params)
+                : specificItemMapper.selectFlatCount(params);
+
+        Map<String, Object> res = new HashMap<>();
+        res.put("data", data);
+        res.put("recordsFiltered", total);
+        return ResponseEntity.ok(res);
+    }
+
+    /** 저장 여부 토글 */
+    @PatchMapping("/api/specific-item/saved")
+    public ResponseEntity<Void> toggleSaved(@RequestBody Map<String, Object> body) {
+        specificItemMapper.updateSaved(body);
+        return ResponseEntity.ok().build();
+    }
+
+    /** 엑셀 다운로드 */
+    @GetMapping("/api/specific-item/excel")
+    public ResponseEntity<byte[]> excel(
+            @RequestParam(required = false) String dataType,
+            @RequestParam(required = false) String demandAgencyName,
+            @RequestParam(required = false) String demandAgencyRegion,
+            @RequestParam(required = false) String vendorBizRegNo,
+            @RequestParam(required = false) String itemCategoryNo,
+            @RequestParam(required = false) String detailItemNo,
+            @RequestParam(required = false) String isMas,
+            @RequestParam(required = false) String isExcellentProduct,
+            @RequestParam(required = false) Integer year,
+            @RequestParam(required = false) String month,
+            @RequestParam(required = false) String rangeStart,
+            @RequestParam(required = false) String rangeEnd,
+            @RequestParam(required = false, defaultValue = "false") boolean showSavedOnly,
+            @RequestParam(required = false, defaultValue = "false") boolean grouped
+    ) {
+        Map<String, Object> params = buildParams(
+                dataType, demandAgencyName, demandAgencyRegion, vendorBizRegNo,
+                itemCategoryNo, detailItemNo, isMas, isExcellentProduct,
+                year, month, rangeStart, rangeEnd, showSavedOnly, grouped, 0, Integer.MAX_VALUE);
+
+        List<Map<String, Object>> rows = grouped
+                ? specificItemMapper.selectGroupedList(params)
+                : specificItemMapper.selectFlatList(params);
+
+        byte[] xlsx = buildExcel(rows, grouped);
+        return ResponseEntity.ok()
+                .header("Content-Disposition", "attachment; filename=\"specific_item.xlsx\"")
+                .header("Content-Type", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")
+                .body(xlsx);
+    }
+
+    private Map<String, Object> buildParams(
+            String dataType, String demandAgencyName, String demandAgencyRegion,
+            String vendorBizRegNo, String itemCategoryNo, String detailItemNo,
+            String isMas, String isExcellentProduct,
+            Integer year, String month, String rangeStart, String rangeEnd,
+            boolean showSavedOnly, boolean grouped, int start, int length) {
+
+        Map<String, Object> p = new HashMap<>();
+        if (ne(dataType))          p.put("dataType", dataType);
+        if (ne(demandAgencyName))  p.put("demandAgencyName", demandAgencyName);
+        if (ne(demandAgencyRegion))p.put("demandAgencyRegion", demandAgencyRegion);
+        if (ne(vendorBizRegNo))    p.put("vendorBizRegNo", vendorBizRegNo);
+        if (ne(itemCategoryNo))    p.put("itemCategoryNo", itemCategoryNo);
+        if (ne(detailItemNo))      p.put("detailItemNo", detailItemNo);
+        if (ne(isMas))             p.put("isMas", isMas);
+        if (ne(isExcellentProduct))p.put("isExcellentProduct", isExcellentProduct);
+        if (year != null)          p.put("year", year);
+        if (ne(month))             p.put("month", month);
+        if (ne(rangeStart))        p.put("rangeStart", rangeStart);
+        if (ne(rangeEnd))          p.put("rangeEnd", rangeEnd);
+        p.put("showSavedOnly", showSavedOnly);
+        p.put("start", start);
+        p.put("length", length);
+        return p;
+    }
+
+    private boolean ne(String v) { return v != null && !v.isBlank(); }
+
+    private byte[] buildExcel(List<Map<String, Object>> rows, boolean grouped) {
+        try (org.apache.poi.xssf.usermodel.XSSFWorkbook wb = new org.apache.poi.xssf.usermodel.XSSFWorkbook()) {
+            org.apache.poi.ss.usermodel.Sheet sheet = wb.createSheet("특정품목");
+            String[] headers = grouped
+                    ? new String[]{"구분","업체명","사업자번호","수요기관명","수요기관지역","계약유형","물품분류번호","세부품명","최초계약일자","최종계약일자","최종계약금액(합계)","계약건수","장기여부","저장"}
+                    : new String[]{"구분","업체명","사업자번호","수요기관명","수요기관지역","계약방법","계약유형","물품분류번호","세부품명번호","세부품명","물품식별명","단위","단가","수량","공급금액","MAS","우수제품","직접구매","중기간경쟁","최초계약일자","계약일자","장기여부","저장"};
+
+            org.apache.poi.ss.usermodel.Row header = sheet.createRow(0);
+            for (int i = 0; i < headers.length; i++) header.createCell(i).setCellValue(headers[i]);
+
+            int rowIdx = 1;
+            for (Map<String, Object> r : rows) {
+                org.apache.poi.ss.usermodel.Row row = sheet.createRow(rowIdx++);
+                if (grouped) {
+                    setCell(row, 0, r.get("dataTypeLabel"));
+                    setCell(row, 1, r.get("vendorName"));
+                    setCell(row, 2, r.get("vendorBizRegNo"));
+                    setCell(row, 3, r.get("demandAgencyName"));
+                    setCell(row, 4, r.get("demandAgencyRegion"));
+                    setCell(row, 5, r.get("contractType"));
+                    setCell(row, 6, r.get("itemCategoryNo"));
+                    setCell(row, 7, r.get("detailItemName"));
+                    setCell(row, 8, r.get("firstContractDate"));
+                    setCell(row, 9, r.get("lastContractDate"));
+                    setCell(row, 10, r.get("totalSupplyAmount"));
+                    setCell(row, 11, r.get("contractCount"));
+                    setCell(row, 12, r.get("isLongTerm"));
+                    setCell(row, 13, r.get("saved"));
+                } else {
+                    setCell(row, 0, r.get("dataTypeLabel"));
+                    setCell(row, 1, r.get("vendorName"));
+                    setCell(row, 2, r.get("vendorBizRegNo"));
+                    setCell(row, 3, r.get("demandAgencyName"));
+                    setCell(row, 4, r.get("demandAgencyRegion"));
+                    setCell(row, 5, r.get("contractMethod"));
+                    setCell(row, 6, r.get("contractType"));
+                    setCell(row, 7, r.get("itemCategoryNo"));
+                    setCell(row, 8, r.get("detailItemNo"));
+                    setCell(row, 9, r.get("detailItemName"));
+                    setCell(row, 10, r.get("itemIdentifierName"));
+                    setCell(row, 11, r.get("unit"));
+                    setCell(row, 12, r.get("unitPrice"));
+                    setCell(row, 13, r.get("quantity"));
+                    setCell(row, 14, r.get("supplyAmount"));
+                    setCell(row, 15, r.get("isMas"));
+                    setCell(row, 16, r.get("isExcellentProduct"));
+                    setCell(row, 17, r.get("isDirectPurchase"));
+                    setCell(row, 18, r.get("isSmeCompetitive"));
+                    setCell(row, 19, r.get("firstContractDate"));
+                    setCell(row, 20, r.get("contractDate"));
+                    setCell(row, 21, r.get("isLongTerm"));
+                    setCell(row, 22, r.get("saved"));
+                }
+            }
+            java.io.ByteArrayOutputStream out = new java.io.ByteArrayOutputStream();
+            wb.write(out);
+            return out.toByteArray();
+        } catch (Exception e) {
+            throw new RuntimeException("엑셀 생성 실패", e);
+        }
+    }
+
+    private void setCell(org.apache.poi.ss.usermodel.Row row, int col, Object val) {
+        org.apache.poi.ss.usermodel.Cell cell = row.createCell(col);
+        if (val == null) { cell.setCellValue(""); return; }
+        if (val instanceof Number) cell.setCellValue(((Number) val).doubleValue());
+        else cell.setCellValue(val.toString());
+    }
+}

--- a/backend/src/main/java/org/example/g2bplatform/mapper/SpecificItemMapper.java
+++ b/backend/src/main/java/org/example/g2bplatform/mapper/SpecificItemMapper.java
@@ -18,4 +18,6 @@ public interface SpecificItemMapper {
     int selectGroupedCount(@Param("p") Map<String, Object> params);
 
     void updateSaved(Map<String, Object> params);
+
+    void updateGroupedSaved(Map<String, Object> params);
 }

--- a/backend/src/main/java/org/example/g2bplatform/mapper/SpecificItemMapper.java
+++ b/backend/src/main/java/org/example/g2bplatform/mapper/SpecificItemMapper.java
@@ -1,0 +1,21 @@
+package org.example.g2bplatform.mapper;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
+import java.util.Map;
+
+@Mapper
+public interface SpecificItemMapper {
+
+    List<Map<String, Object>> selectFlatList(@Param("p") Map<String, Object> params);
+
+    int selectFlatCount(@Param("p") Map<String, Object> params);
+
+    List<Map<String, Object>> selectGroupedList(@Param("p") Map<String, Object> params);
+
+    int selectGroupedCount(@Param("p") Map<String, Object> params);
+
+    void updateSaved(Map<String, Object> params);
+}

--- a/backend/src/main/java/org/example/g2bplatform/service/SpecificItemCsvJobService.java
+++ b/backend/src/main/java/org/example/g2bplatform/service/SpecificItemCsvJobService.java
@@ -55,6 +55,7 @@ public class SpecificItemCsvJobService {
 
     private final JdbcTemplate jdbc;
     private final TaskExecutor csvJobExecutor;
+    private final SpecificItemEtlService specificItemEtlService;
 
     public CsvUploadJobDto startSpecificItemJob(MultipartFile file, String uploader) {
         String jobId = UUID.randomUUID().toString();
@@ -149,6 +150,11 @@ public class SpecificItemCsvJobService {
                     result.getErrorMessage(),
                     jobId
             );
+
+            // CSV 적재 성공 시 flat 테이블 ETL 자동 트리거
+            if ("SUCCESS".equals(finalStatus)) {
+                specificItemEtlService.startEtlJob(uploader);
+            }
         } catch (Exception e) {
             log.error("Job 실패: {}", jobId, e);
             jdbc.update(

--- a/backend/src/main/java/org/example/g2bplatform/service/SpecificItemEtlService.java
+++ b/backend/src/main/java/org/example/g2bplatform/service/SpecificItemEtlService.java
@@ -22,7 +22,7 @@ public class SpecificItemEtlService {
 
     private static final String INSERT_SQL =
             "INSERT IGNORE INTO specific_item_flat (" +
-            "  data_type, contract_no, change_seq, item_seq, is_final_contract, is_long_term," +
+            "  data_type, contract_no, change_seq, item_seq, is_final_contract, is_long_term, first_year_contract_no," +
             "  demand_agency_code, demand_agency_name, demand_agency_region," +
             "  vendor_name, vendor_biz_reg_no, vendor_enterprise_type, vendor_region," +
             "  contract_name, contract_method, bid_notice_no, contract_type, delivery_contract_type," +
@@ -33,7 +33,7 @@ public class SpecificItemEtlService {
             "  contract_date, first_contract_date," +
             "  jurisdiction_type, delivery_location, source_file" +
             ") VALUES (" +
-            "  ?,?,?,?,?,?," +
+            "  ?,?,?,?,?,?,?," +
             "  ?,?,?," +
             "  ?,?,?,?," +
             "  ?,?,?,?,?," +
@@ -53,7 +53,7 @@ public class SpecificItemEtlService {
         String jobId = UUID.randomUUID().toString();
 
         long total = jdbc.queryForObject(
-                "SELECT COUNT(*) FROM procurement_specific_item_raw WHERE business_type = '물품'",
+                "SELECT COUNT(*) FROM procurement_specific_item_raw WHERE business_type = '물품' AND is_final_contract = 'Y'",
                 Long.class);
 
         jdbc.update(
@@ -111,7 +111,7 @@ public class SpecificItemEtlService {
         try {
             while (true) {
                 List<Map<String, Object>> rows = jdbc.queryForList(
-                        "SELECT * FROM procurement_specific_item_raw WHERE business_type = '물품' AND id > ? ORDER BY id LIMIT ?",
+                        "SELECT * FROM procurement_specific_item_raw WHERE business_type = '물품' AND is_final_contract = 'Y' AND id > ? ORDER BY id LIMIT ?",
                         lastId, BATCH_SIZE);
 
                 if (rows.isEmpty()) break;
@@ -131,6 +131,10 @@ public class SpecificItemEtlService {
                         (int) processed, (int) inserted, (int) (processed - inserted), jobId);
             }
 
+            // flat 적재 완료 → grouped 재집계 (saved 보존)
+            jdbc.update("UPDATE csv_upload_job SET message='grouped 집계 중' WHERE id=?", jobId);
+            rebuildGrouped();
+
             jdbc.update("UPDATE csv_upload_job SET status='SUCCESS', message='완료', processed_rows=?, inserted_count=?, skipped_count=?, finished_at=NOW() WHERE id=?",
                     (int) processed, (int) inserted, (int) (processed - inserted), jobId);
             log.info("[ETL] 완료 jobId={}, inserted={}", jobId, inserted);
@@ -142,13 +146,75 @@ public class SpecificItemEtlService {
         }
     }
 
+    /**
+     * specific_item_flat → specific_item_grouped 재집계.
+     * 단기/단일계약은 1행 그대로, 장기계약은 초년도계약번호로 연차를 1행으로 병합.
+     * 기존 grouped의 saved 값은 묶음 키(data_type, group_key, vendor_biz_reg_no) 기준으로 보존.
+     */
+    private void rebuildGrouped() {
+        log.info("[ETL] grouped 재집계 시작");
+
+        // 1) 기존 saved 백업
+        jdbc.execute("DROP TEMPORARY TABLE IF EXISTS tmp_grouped_saved");
+        jdbc.execute(
+                "CREATE TEMPORARY TABLE tmp_grouped_saved AS " +
+                "SELECT data_type, group_key, vendor_biz_reg_no, saved " +
+                "FROM specific_item_grouped WHERE saved = 'Y'");
+
+        // 2) 재집계
+        jdbc.update("TRUNCATE TABLE specific_item_grouped");
+        int grouped = jdbc.update(
+                "INSERT INTO specific_item_grouped (" +
+                "  data_type, group_key, vendor_biz_reg_no, first_year_contract_no, contract_no," +
+                "  vendor_name, demand_agency_name, demand_agency_region, contract_method, contract_type," +
+                "  item_category_no, detail_item_name, is_long_term," +
+                "  first_contract_date, last_contract_date, total_supply_amount, contract_count, saved" +
+                ") SELECT" +
+                "  data_type," +
+                "  COALESCE(first_year_contract_no, contract_no) AS group_key," +
+                "  vendor_biz_reg_no," +
+                "  MAX(first_year_contract_no)," +
+                "  MIN(contract_no)," +
+                "  MAX(vendor_name)," +
+                "  MAX(demand_agency_name)," +
+                "  MIN(demand_agency_region)," +
+                "  MAX(contract_method)," +
+                "  MAX(contract_type)," +
+                "  MAX(item_category_no)," +
+                "  MAX(detail_item_name)," +
+                "  MAX(is_long_term)," +
+                "  MIN(first_contract_date)," +
+                "  MAX(contract_date)," +
+                "  SUM(COALESCE(supply_amount, 0))," +
+                "  COUNT(DISTINCT contract_no)," +
+                "  'N'" +
+                " FROM specific_item_flat" +
+                " WHERE is_active = 'Y'" +
+                " GROUP BY data_type, COALESCE(first_year_contract_no, contract_no), vendor_biz_reg_no");
+
+        // 3) saved 복원
+        int restored = jdbc.update(
+                "UPDATE specific_item_grouped g " +
+                "JOIN tmp_grouped_saved t " +
+                "  ON g.data_type = t.data_type" +
+                "  AND g.group_key = t.group_key" +
+                "  AND g.vendor_biz_reg_no <=> t.vendor_biz_reg_no " +
+                "SET g.saved = 'Y'");
+
+        jdbc.execute("DROP TEMPORARY TABLE IF EXISTS tmp_grouped_saved");
+        log.info("[ETL] grouped 재집계 완료 grouped={}, saved복원={}", grouped, restored);
+    }
+
     private Object[] toParams(Map<String, Object> r) {
         String contractType = str(r.get("contract_type"));
         String deliveryType = str(r.get("delivery_contract_type"));
         String dataType = ("제3자단가계약".equals(contractType) && "납품".equals(deliveryType))
                 ? "shopping_mall" : "general";
         String longTermType = str(r.get("new_long_term_type"));
-        String isLongTerm = (longTermType != null) ? "Y" : "N";
+        boolean isLong = "신규(장기)".equals(longTermType)
+                || "장기".equals(longTermType)
+                || "계속비".equals(longTermType);
+        String isLongTerm = isLong ? "Y" : "N";
 
         return new Object[]{
                 dataType,
@@ -157,6 +223,7 @@ public class SpecificItemEtlService {
                 toInt(r.get("item_seq"), 1),
                 flag(str(r.get("is_final_contract"))),
                 isLongTerm,
+                str(r.get("first_year_contract_no")),
                 str(r.get("demand_agency_code")),
                 str(r.get("demand_agency_name")),
                 str(r.get("demand_agency_region")),

--- a/backend/src/main/java/org/example/g2bplatform/service/SpecificItemEtlService.java
+++ b/backend/src/main/java/org/example/g2bplatform/service/SpecificItemEtlService.java
@@ -1,0 +1,230 @@
+package org.example.g2bplatform.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.g2bplatform.DTO.CsvUploadJobDto;
+import org.springframework.core.task.TaskExecutor;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SpecificItemEtlService {
+
+    private static final int BATCH_SIZE = 2_000;
+
+    private static final String INSERT_SQL =
+            "INSERT IGNORE INTO specific_item_flat (" +
+            "  data_type, contract_no, change_seq, item_seq, is_final_contract, is_long_term," +
+            "  demand_agency_code, demand_agency_name, demand_agency_region," +
+            "  vendor_name, vendor_biz_reg_no, vendor_enterprise_type, vendor_region," +
+            "  contract_name, contract_method, bid_notice_no, contract_type, delivery_contract_type," +
+            "  item_category_no, item_category_name, detail_item_no, detail_item_name," +
+            "  item_identifier_no, item_identifier_name, unit," +
+            "  unit_price, quantity, quantity_change, supply_amount, supply_amount_change," +
+            "  is_mas, is_excellent_product, is_direct_purchase, is_sme_competitive," +
+            "  contract_date, first_contract_date," +
+            "  jurisdiction_type, delivery_location, source_file" +
+            ") VALUES (" +
+            "  ?,?,?,?,?,?," +
+            "  ?,?,?," +
+            "  ?,?,?,?," +
+            "  ?,?,?,?,?," +
+            "  ?,?,?,?," +
+            "  ?,?,?," +
+            "  ?,?,?,?,?," +
+            "  ?,?,?,?," +
+            "  ?,?," +
+            "  ?,?,?" +
+            ")";
+
+    private final JdbcTemplate jdbc;
+    private final TaskExecutor csvJobExecutor;
+
+    /** CSV 업로드 완료 후 자동 트리거 — jobId 반환 */
+    public CsvUploadJobDto startEtlJob(String triggeredBy) {
+        String jobId = UUID.randomUUID().toString();
+
+        long total = jdbc.queryForObject(
+                "SELECT COUNT(*) FROM procurement_specific_item_raw WHERE business_type = '물품'",
+                Long.class);
+
+        jdbc.update(
+                "INSERT INTO csv_upload_job (id, upload_type, file_name, file_size_bytes, temp_path, status, message, total_rows, uploader, created_at, updated_at) " +
+                "VALUES (?,?,?,?,?,?,?,?,?,NOW(),NOW())",
+                jobId, "specific_item_etl", "ETL", 0L, "", "QUEUED", "대기 중", (int) total, triggeredBy
+        );
+
+        csvJobExecutor.execute(() -> runEtl(jobId, total));
+
+        return CsvUploadJobDto.builder()
+                .jobId(jobId)
+                .uploadType("specific_item_etl")
+                .status("QUEUED")
+                .message("대기 중")
+                .totalRows((int) total)
+                .processedRows(0)
+                .insertedCount(0)
+                .skippedCount(0)
+                .build();
+    }
+
+    public CsvUploadJobDto getJob(String jobId) {
+        List<CsvUploadJobDto> list = jdbc.query(
+                "SELECT id, upload_type, file_name, file_size_bytes, status, message, total_rows, processed_rows, inserted_count, skipped_count, started_at, finished_at, error_message " +
+                "FROM csv_upload_job WHERE id = ?",
+                (rs, rowNum) -> CsvUploadJobDto.builder()
+                        .jobId(rs.getString("id"))
+                        .uploadType(rs.getString("upload_type"))
+                        .fileName(rs.getString("file_name"))
+                        .fileSizeBytes((Long) rs.getObject("file_size_bytes"))
+                        .status(rs.getString("status"))
+                        .message(rs.getString("message"))
+                        .totalRows((Integer) rs.getObject("total_rows"))
+                        .processedRows(rs.getInt("processed_rows"))
+                        .insertedCount(rs.getInt("inserted_count"))
+                        .skippedCount(rs.getInt("skipped_count"))
+                        .startedAt(rs.getObject("started_at", LocalDateTime.class))
+                        .finishedAt(rs.getObject("finished_at", LocalDateTime.class))
+                        .errorMessage(rs.getString("error_message"))
+                        .build(),
+                jobId
+        );
+        return list.isEmpty() ? null : list.get(0);
+    }
+
+    private void runEtl(String jobId, long total) {
+        jdbc.update("UPDATE csv_upload_job SET status='RUNNING', message='ETL 처리 중', started_at=NOW() WHERE id=?", jobId);
+        log.info("[ETL] 시작 jobId={}, total={}", jobId, total);
+
+        long processed = 0;
+        long inserted = 0;
+        long lastId = 0;
+
+        try {
+            while (true) {
+                List<Map<String, Object>> rows = jdbc.queryForList(
+                        "SELECT * FROM procurement_specific_item_raw WHERE business_type = '물품' AND id > ? ORDER BY id LIMIT ?",
+                        lastId, BATCH_SIZE);
+
+                if (rows.isEmpty()) break;
+
+                List<Object[]> batch = new ArrayList<>(rows.size());
+                for (Map<String, Object> r : rows) {
+                    batch.add(toParams(r));
+                    processed++;
+                }
+
+                int[] results = jdbc.batchUpdate(INSERT_SQL, batch);
+                for (int res : results) if (res > 0) inserted++;
+
+                lastId = toLong(rows.get(rows.size() - 1).get("id"));
+
+                jdbc.update("UPDATE csv_upload_job SET processed_rows=?, inserted_count=?, skipped_count=?, message='ETL 처리 중' WHERE id=?",
+                        (int) processed, (int) inserted, (int) (processed - inserted), jobId);
+            }
+
+            jdbc.update("UPDATE csv_upload_job SET status='SUCCESS', message='완료', processed_rows=?, inserted_count=?, skipped_count=?, finished_at=NOW() WHERE id=?",
+                    (int) processed, (int) inserted, (int) (processed - inserted), jobId);
+            log.info("[ETL] 완료 jobId={}, inserted={}", jobId, inserted);
+
+        } catch (Exception e) {
+            log.error("[ETL] 실패 jobId={}", jobId, e);
+            jdbc.update("UPDATE csv_upload_job SET status='FAILED', message='실패', error_message=?, finished_at=NOW() WHERE id=?",
+                    e.getMessage(), jobId);
+        }
+    }
+
+    private Object[] toParams(Map<String, Object> r) {
+        String contractType = str(r.get("contract_type"));
+        String deliveryType = str(r.get("delivery_contract_type"));
+        String dataType = ("제3자단가계약".equals(contractType) && "납품".equals(deliveryType))
+                ? "shopping_mall" : "general";
+        String longTermType = str(r.get("new_long_term_type"));
+        String isLongTerm = (longTermType != null) ? "Y" : "N";
+
+        return new Object[]{
+                dataType,
+                str(r.get("contract_no")),
+                str(r.get("change_seq")),
+                toInt(r.get("item_seq"), 1),
+                flag(str(r.get("is_final_contract"))),
+                isLongTerm,
+                str(r.get("demand_agency_code")),
+                str(r.get("demand_agency_name")),
+                str(r.get("demand_agency_region")),
+                str(r.get("vendor_name")),
+                str(r.get("vendor_biz_reg_no")),
+                str(r.get("vendor_enterprise_type")),
+                str(r.get("vendor_region")),
+                str(r.get("contract_name")),
+                str(r.get("contract_method")),
+                str(r.get("base_contract_no")),
+                contractType,
+                deliveryType,
+                str(r.get("item_category_no")),
+                str(r.get("item_category_name")),
+                str(r.get("detail_item_no")),
+                str(r.get("detail_item_name")),
+                str(r.get("item_identifier_no")),
+                str(r.get("item_name")),
+                str(r.get("unit")),
+                parseLong(str(r.get("unit_price_raw"))),
+                parseLong(str(r.get("quantity_raw"))),
+                parseLong(str(r.get("quantity_change_raw"))),
+                parseLong(str(r.get("supply_amount_raw"))),
+                parseLong(str(r.get("supply_amount_change_raw"))),
+                flag(str(r.get("is_mas"))),
+                flag(str(r.get("is_excellent_product"))),
+                flag(str(r.get("is_direct_purchase"))),
+                flag(str(r.get("is_sme_competitive"))),
+                toDate(str(r.get("contract_date"))),
+                toDate(str(r.get("first_contract_date"))),
+                str(r.get("jurisdiction_type")),
+                str(r.get("delivery_location")),
+                str(r.get("source_file"))
+        };
+    }
+
+    private String str(Object v) {
+        if (v == null) return null;
+        String s = v.toString().trim();
+        return s.isEmpty() ? null : s;
+    }
+
+    private String flag(String v) {
+        if (v == null || v.isEmpty()) return null;
+        String u = v.toUpperCase();
+        return ("Y".equals(u) || "N".equals(u)) ? u : null;
+    }
+
+    private int toInt(Object v, int def) {
+        if (v == null) return def;
+        try { return Integer.parseInt(v.toString().trim()); } catch (Exception e) { return def; }
+    }
+
+    private long toLong(Object v) {
+        if (v == null) return 0L;
+        try { return Long.parseLong(v.toString().trim()); } catch (Exception e) { return 0L; }
+    }
+
+    private Long parseLong(String v) {
+        if (v == null || v.isEmpty()) return null;
+        try { return Long.parseLong(v.replace(",", "").trim()); } catch (Exception e) { return null; }
+    }
+
+    private String toDate(String v) {
+        if (v == null || v.length() < 8) return null;
+        if (v.length() == 8 && v.matches("\\d{8}")) {
+            return v.substring(0, 4) + "-" + v.substring(4, 6) + "-" + v.substring(6, 8);
+        }
+        return v;
+    }
+}

--- a/backend/src/main/resources/db/migration/V12__create_specific_item_flat.sql
+++ b/backend/src/main/resources/db/migration/V12__create_specific_item_flat.sql
@@ -1,0 +1,84 @@
+-- 특정품목 조달내역 통합 flat 테이블
+-- procurement_specific_item_raw에서 ETL하여 물품(일반계약)과 쇼핑몰(제3자단가) 데이터를 단일 테이블로 관리
+-- data_type: shopping_mall(제3자단가+납품) | general(총액·일반단가+계약)
+CREATE TABLE IF NOT EXISTS specific_item_flat (
+    id                      BIGINT          NOT NULL AUTO_INCREMENT PRIMARY KEY,
+
+    -- 데이터 구분
+    data_type               VARCHAR(20)     NOT NULL COMMENT 'shopping_mall | general',
+
+    -- 계약 기본
+    contract_no             VARCHAR(30)     NOT NULL COMMENT '계약번호',
+    change_seq              VARCHAR(5)      NOT NULL DEFAULT '' COMMENT '계약변경차수',
+    item_seq                SMALLINT        NOT NULL DEFAULT 1 COMMENT '품목순번',
+    is_final_contract       CHAR(1)                  DEFAULT NULL COMMENT '최종계약여부 Y/N',
+    is_long_term            CHAR(1)         NOT NULL DEFAULT 'N' COMMENT '장기계약여부 Y/N',
+
+    -- 기관
+    demand_agency_code      VARCHAR(20)              DEFAULT NULL,
+    demand_agency_name      VARCHAR(200)             DEFAULT NULL COMMENT '수요기관명',
+    demand_agency_region    VARCHAR(100)             DEFAULT NULL COMMENT '수요기관지역',
+
+    -- 업체
+    vendor_name             VARCHAR(200)             DEFAULT NULL COMMENT '업체명',
+    vendor_biz_reg_no       VARCHAR(15)              DEFAULT NULL COMMENT '사업자등록번호',
+    vendor_enterprise_type  VARCHAR(30)              DEFAULT NULL COMMENT '기업구분',
+    vendor_region           VARCHAR(100)             DEFAULT NULL COMMENT '업체소재지역',
+
+    -- 계약 정보
+    contract_name           VARCHAR(500)             DEFAULT NULL COMMENT '계약명',
+    contract_method         VARCHAR(20)              DEFAULT NULL COMMENT '계약방법',
+    bid_notice_no           VARCHAR(50)              DEFAULT NULL COMMENT '입찰공고번호',
+    contract_type           VARCHAR(30)              DEFAULT NULL COMMENT '계약유형(총액/제3자단가 등)',
+    delivery_contract_type  VARCHAR(10)              DEFAULT NULL COMMENT '납품유형(계약/납품)',
+
+    -- 품목
+    item_category_no        VARCHAR(10)              DEFAULT NULL COMMENT '물품분류번호',
+    item_category_name      VARCHAR(100)             DEFAULT NULL COMMENT '물품분류명',
+    detail_item_no          VARCHAR(15)              DEFAULT NULL COMMENT '세부품명번호',
+    detail_item_name        VARCHAR(100)             DEFAULT NULL COMMENT '세부품명',
+    item_identifier_no      VARCHAR(15)              DEFAULT NULL COMMENT '물품식별번호',
+    item_identifier_name    VARCHAR(300)             DEFAULT NULL COMMENT '물품식별명',
+    unit                    VARCHAR(30)              DEFAULT NULL COMMENT '단위',
+
+    -- 금액 (원본 문자열 → 정수 변환, 변환 불가 시 NULL)
+    unit_price              BIGINT                   DEFAULT NULL COMMENT '단가',
+    quantity                BIGINT                   DEFAULT NULL COMMENT '수량',
+    quantity_change         BIGINT                   DEFAULT NULL COMMENT '수량변경',
+    supply_amount           BIGINT                   DEFAULT NULL COMMENT '공급금액',
+    supply_amount_change    BIGINT                   DEFAULT NULL COMMENT '공급금액변경',
+
+    -- 플래그
+    is_mas                  CHAR(1)                  DEFAULT NULL COMMENT 'MAS 여부 Y/N',
+    is_excellent_product    CHAR(1)                  DEFAULT NULL COMMENT '우수제품 Y/N',
+    is_direct_purchase      CHAR(1)                  DEFAULT NULL COMMENT '직접구매 Y/N',
+    is_sme_competitive      CHAR(1)                  DEFAULT NULL COMMENT '중기간경쟁 Y/N',
+
+    -- 날짜
+    contract_date           DATE                     DEFAULT NULL COMMENT '계약일자',
+    first_contract_date     DATE                     DEFAULT NULL COMMENT '최초계약일자',
+
+    -- 부가
+    jurisdiction_type       VARCHAR(30)              DEFAULT NULL,
+    delivery_location       VARCHAR(300)             DEFAULT NULL COMMENT '납품장소',
+    source_file             VARCHAR(200)             DEFAULT NULL,
+
+    -- 저장 여부 (사용자가 관심 표시)
+    saved                   CHAR(1)         NOT NULL DEFAULT 'N',
+
+    -- ETL 메타
+    etl_loaded_at           DATETIME        NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    is_active               CHAR(1)         NOT NULL DEFAULT 'Y',
+
+    UNIQUE KEY uq_specific_item_flat (contract_no, change_seq, item_seq),
+    INDEX idx_data_type          (data_type),
+    INDEX idx_contract_date      (contract_date),
+    INDEX idx_first_contract_date (first_contract_date),
+    INDEX idx_vendor_biz_reg_no  (vendor_biz_reg_no),
+    INDEX idx_demand_agency_name (demand_agency_name(50)),
+    INDEX idx_item_category_no   (item_category_no),
+    INDEX idx_detail_item_no     (detail_item_no),
+    INDEX idx_is_final_contract  (is_final_contract),
+    INDEX idx_saved              (saved)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+  COMMENT='특정품목 조달내역 통합 flat 테이블 (물품+쇼핑몰, RAW ETL 결과)';

--- a/backend/src/main/resources/db/migration/V13__add_first_year_contract_no_to_specific_item_flat.sql
+++ b/backend/src/main/resources/db/migration/V13__add_first_year_contract_no_to_specific_item_flat.sql
@@ -1,0 +1,3 @@
+ALTER TABLE specific_item_flat
+    ADD COLUMN first_year_contract_no VARCHAR(30) DEFAULT NULL COMMENT '초년도계약번호 (장기계속계약 묶음 키)' AFTER is_long_term,
+    ADD INDEX idx_first_year_contract_no (first_year_contract_no);

--- a/backend/src/main/resources/db/migration/V14__create_specific_item_grouped.sql
+++ b/backend/src/main/resources/db/migration/V14__create_specific_item_grouped.sql
@@ -1,0 +1,44 @@
+-- 특정품목 통합 grouped 테이블
+-- specific_item_flat에서 ETL 시점에 미리 집계해 두는 물리 테이블.
+-- 단기/단일계약은 1행 그대로, 장기계약은 초년도계약번호(first_year_contract_no) 기준으로 연차를 1행으로 병합.
+-- 묶음 키(group_key) = COALESCE(first_year_contract_no, contract_no)
+CREATE TABLE IF NOT EXISTS specific_item_grouped (
+    id                      BIGINT          NOT NULL AUTO_INCREMENT PRIMARY KEY,
+
+    -- 묶음 키
+    data_type               VARCHAR(20)     NOT NULL COMMENT 'shopping_mall | general',
+    group_key               VARCHAR(30)     NOT NULL COMMENT 'COALESCE(초년도계약번호, 계약번호)',
+    vendor_biz_reg_no       VARCHAR(15)              DEFAULT NULL COMMENT '사업자등록번호',
+
+    -- 대표/집계 표시값
+    first_year_contract_no  VARCHAR(30)              DEFAULT NULL COMMENT '초년도계약번호 (장기계약만)',
+    contract_no             VARCHAR(30)              DEFAULT NULL COMMENT '대표 계약번호 MIN',
+    vendor_name             VARCHAR(200)             DEFAULT NULL COMMENT '업체명',
+    demand_agency_name      VARCHAR(200)             DEFAULT NULL COMMENT '수요기관명',
+    demand_agency_region    VARCHAR(100)             DEFAULT NULL COMMENT '수요기관지역',
+    contract_method         VARCHAR(20)              DEFAULT NULL COMMENT '계약방법',
+    contract_type           VARCHAR(30)              DEFAULT NULL COMMENT '계약유형',
+    item_category_no        VARCHAR(10)              DEFAULT NULL COMMENT '물품분류번호',
+    detail_item_name        VARCHAR(100)             DEFAULT NULL COMMENT '세부품명',
+    is_long_term            CHAR(1)         NOT NULL DEFAULT 'N' COMMENT '장기계약여부 Y/N',
+
+    -- 집계값
+    first_contract_date     DATE                     DEFAULT NULL COMMENT '최초계약일자 MIN',
+    last_contract_date      DATE                     DEFAULT NULL COMMENT '최종계약일자 MAX',
+    total_supply_amount     BIGINT          NOT NULL DEFAULT 0 COMMENT '공급금액 합산',
+    contract_count          INT             NOT NULL DEFAULT 1 COMMENT '묶인 계약번호 수',
+
+    -- 저장 여부 (묶음 단위 독립 관리)
+    saved                   CHAR(1)         NOT NULL DEFAULT 'N',
+
+    etl_loaded_at           DATETIME        NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    UNIQUE KEY uq_specific_item_grouped (data_type, group_key, vendor_biz_reg_no),
+    INDEX idx_grp_data_type          (data_type),
+    INDEX idx_grp_last_contract_date (last_contract_date),
+    INDEX idx_grp_demand_agency_name (demand_agency_name(50)),
+    INDEX idx_grp_vendor_biz_reg_no  (vendor_biz_reg_no),
+    INDEX idx_grp_item_category_no   (item_category_no),
+    INDEX idx_grp_saved              (saved)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+  COMMENT='특정품목 통합 grouped 테이블 (장기계약 초년도번호 묶음, ETL 집계 결과)';

--- a/backend/src/main/resources/org/example/g2bplatform/mapper/SpecificItemMapper.xml
+++ b/backend/src/main/resources/org/example/g2bplatform/mapper/SpecificItemMapper.xml
@@ -1,0 +1,159 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="org.example.g2bplatform.mapper.SpecificItemMapper">
+
+    <sql id="dataTypeLabel">
+        CASE data_type
+            WHEN 'shopping_mall' THEN '쇼핑몰(제3자단가)'
+            ELSE '물품(일반계약)'
+        END AS dataTypeLabel
+    </sql>
+
+    <sql id="commonWhere">
+        WHERE is_active = 'Y'
+        <if test="p.dataType != null">
+            AND data_type = #{p.dataType}
+        </if>
+        <if test="p.demandAgencyName != null">
+            AND demand_agency_name LIKE CONCAT('%', #{p.demandAgencyName}, '%')
+        </if>
+        <if test="p.demandAgencyRegion != null">
+            AND demand_agency_region LIKE CONCAT('%', #{p.demandAgencyRegion}, '%')
+        </if>
+        <if test="p.vendorBizRegNo != null">
+            AND vendor_biz_reg_no = #{p.vendorBizRegNo}
+        </if>
+        <if test="p.itemCategoryNo != null">
+            AND item_category_no LIKE CONCAT('%', #{p.itemCategoryNo}, '%')
+        </if>
+        <if test="p.detailItemNo != null">
+            AND detail_item_no = #{p.detailItemNo}
+        </if>
+        <if test="p.isMas != null">
+            AND is_mas = #{p.isMas}
+        </if>
+        <if test="p.isExcellentProduct != null">
+            AND is_excellent_product = #{p.isExcellentProduct}
+        </if>
+        <if test="p.year != null">
+            AND contract_date &gt;= CONCAT(#{p.year}, '-01-01')
+            AND contract_date &lt;  DATE_ADD(CONCAT(#{p.year}, '-01-01'), INTERVAL 1 YEAR)
+        </if>
+        <if test="p.month != null">
+            AND contract_date &gt;= CONCAT(#{p.month}, '-01')
+            AND contract_date &lt;  DATE_ADD(CONCAT(#{p.month}, '-01'), INTERVAL 1 MONTH)
+        </if>
+        <if test="p.rangeStart != null and p.rangeEnd != null">
+            AND contract_date &gt;= CONCAT(#{p.rangeStart}, '-01')
+            AND contract_date &lt;  DATE_ADD(CONCAT(#{p.rangeEnd}, '-01'), INTERVAL 1 MONTH)
+        </if>
+        <if test="p.showSavedOnly == true">
+            AND saved = 'Y'
+        </if>
+    </sql>
+
+    <!-- ==================== FLAT ==================== -->
+
+    <select id="selectFlatList" resultType="map">
+        SELECT
+            id                                                  AS id,
+            <include refid="dataTypeLabel"/>,
+            data_type                                           AS dataType,
+            contract_no                                         AS contractNo,
+            change_seq                                          AS changeSeq,
+            item_seq                                            AS itemSeq,
+            is_final_contract                                   AS isFinalContract,
+            is_long_term                                        AS isLongTerm,
+            demand_agency_name                                  AS demandAgencyName,
+            demand_agency_region                                AS demandAgencyRegion,
+            vendor_name                                         AS vendorName,
+            vendor_biz_reg_no                                   AS vendorBizRegNo,
+            contract_name                                       AS contractName,
+            contract_method                                     AS contractMethod,
+            bid_notice_no                                       AS bidNoticeNo,
+            contract_type                                       AS contractType,
+            delivery_contract_type                              AS deliveryContractType,
+            item_category_no                                    AS itemCategoryNo,
+            item_category_name                                  AS itemCategoryName,
+            detail_item_no                                      AS detailItemNo,
+            detail_item_name                                    AS detailItemName,
+            item_identifier_no                                  AS itemIdentifierNo,
+            item_identifier_name                                AS itemIdentifierName,
+            unit                                                AS unit,
+            unit_price                                          AS unitPrice,
+            quantity                                            AS quantity,
+            supply_amount                                       AS supplyAmount,
+            is_mas                                              AS isMas,
+            is_excellent_product                                AS isExcellentProduct,
+            is_direct_purchase                                  AS isDirectPurchase,
+            is_sme_competitive                                  AS isSmeCompetitive,
+            DATE_FORMAT(contract_date, '%Y-%m-%d')              AS contractDate,
+            DATE_FORMAT(first_contract_date, '%Y-%m-%d')        AS firstContractDate,
+            IFNULL(saved, 'N')                                  AS saved
+        FROM specific_item_flat
+        <include refid="commonWhere"/>
+        ORDER BY contract_date DESC, contract_no, item_seq
+        LIMIT #{p.start}, #{p.length}
+    </select>
+
+    <select id="selectFlatCount" resultType="int">
+        SELECT COUNT(*)
+        FROM specific_item_flat
+        <include refid="commonWhere"/>
+    </select>
+
+    <!-- ==================== GROUPED ==================== -->
+
+    <select id="selectGroupedList" resultType="map">
+        SELECT
+            MIN(id)                                             AS id,
+            <include refid="dataTypeLabel"/>,
+            data_type                                           AS dataType,
+            contract_no                                         AS contractNo,
+            vendor_name                                         AS vendorName,
+            vendor_biz_reg_no                                   AS vendorBizRegNo,
+            demand_agency_name                                  AS demandAgencyName,
+            demand_agency_region                                AS demandAgencyRegion,
+            contract_method                                     AS contractMethod,
+            contract_type                                       AS contractType,
+            item_category_no                                    AS itemCategoryNo,
+            detail_item_name                                    AS detailItemName,
+            MAX(is_long_term)                                   AS isLongTerm,
+            DATE_FORMAT(MIN(first_contract_date), '%Y-%m-%d')  AS firstContractDate,
+            DATE_FORMAT(MAX(contract_date), '%Y-%m-%d')        AS lastContractDate,
+            SUM(COALESCE(supply_amount, 0))                    AS totalSupplyAmount,
+            COUNT(*)                                            AS contractCount,
+            MAX(IFNULL(saved, 'N'))                            AS saved
+        FROM specific_item_flat
+        <include refid="commonWhere"/>
+        GROUP BY data_type, contract_no, vendor_biz_reg_no, demand_agency_name,
+                 contract_method, contract_type, item_category_no, detail_item_name, vendor_name
+        ORDER BY lastContractDate DESC
+        LIMIT #{p.start}, #{p.length}
+    </select>
+
+    <select id="selectGroupedCount" resultType="int">
+        SELECT COUNT(*) FROM (
+            SELECT contract_no
+            FROM specific_item_flat
+            <include refid="commonWhere"/>
+            GROUP BY data_type, contract_no, vendor_biz_reg_no, demand_agency_name,
+                     contract_method, contract_type, item_category_no, detail_item_name, vendor_name
+        ) t
+    </select>
+
+    <!-- ==================== SAVED ==================== -->
+
+    <update id="updateSaved">
+        UPDATE specific_item_flat
+        SET saved = #{saved}
+        WHERE contract_no = #{contractNo}
+        <if test="itemSeq != null">
+            AND item_seq = #{itemSeq}
+        </if>
+    </update>
+
+</mapper>

--- a/backend/src/main/resources/org/example/g2bplatform/mapper/SpecificItemMapper.xml
+++ b/backend/src/main/resources/org/example/g2bplatform/mapper/SpecificItemMapper.xml
@@ -107,12 +107,48 @@
 
     <!-- ==================== GROUPED ==================== -->
 
+    <sql id="groupedWhere">
+        WHERE 1=1
+        <if test="p.dataType != null">
+            AND data_type = #{p.dataType}
+        </if>
+        <if test="p.demandAgencyName != null">
+            AND demand_agency_name LIKE CONCAT('%', #{p.demandAgencyName}, '%')
+        </if>
+        <if test="p.demandAgencyRegion != null">
+            AND demand_agency_region LIKE CONCAT('%', #{p.demandAgencyRegion}, '%')
+        </if>
+        <if test="p.vendorBizRegNo != null">
+            AND vendor_biz_reg_no = #{p.vendorBizRegNo}
+        </if>
+        <if test="p.itemCategoryNo != null">
+            AND item_category_no LIKE CONCAT('%', #{p.itemCategoryNo}, '%')
+        </if>
+        <if test="p.year != null">
+            AND last_contract_date &gt;= CONCAT(#{p.year}, '-01-01')
+            AND last_contract_date &lt;  DATE_ADD(CONCAT(#{p.year}, '-01-01'), INTERVAL 1 YEAR)
+        </if>
+        <if test="p.month != null">
+            AND last_contract_date &gt;= CONCAT(#{p.month}, '-01')
+            AND last_contract_date &lt;  DATE_ADD(CONCAT(#{p.month}, '-01'), INTERVAL 1 MONTH)
+        </if>
+        <if test="p.rangeStart != null and p.rangeEnd != null">
+            AND last_contract_date &gt;= CONCAT(#{p.rangeStart}, '-01')
+            AND last_contract_date &lt;  DATE_ADD(CONCAT(#{p.rangeEnd}, '-01'), INTERVAL 1 MONTH)
+        </if>
+        <if test="p.showSavedOnly == true">
+            AND saved = 'Y'
+        </if>
+    </sql>
+
     <select id="selectGroupedList" resultType="map">
         SELECT
-            MIN(id)                                             AS id,
+            id                                                  AS id,
             <include refid="dataTypeLabel"/>,
             data_type                                           AS dataType,
+            group_key                                           AS groupKey,
             contract_no                                         AS contractNo,
+            first_year_contract_no                              AS firstYearContractNo,
             vendor_name                                         AS vendorName,
             vendor_biz_reg_no                                   AS vendorBizRegNo,
             demand_agency_name                                  AS demandAgencyName,
@@ -121,28 +157,22 @@
             contract_type                                       AS contractType,
             item_category_no                                    AS itemCategoryNo,
             detail_item_name                                    AS detailItemName,
-            MAX(is_long_term)                                   AS isLongTerm,
-            DATE_FORMAT(MIN(first_contract_date), '%Y-%m-%d')  AS firstContractDate,
-            DATE_FORMAT(MAX(contract_date), '%Y-%m-%d')        AS lastContractDate,
-            SUM(COALESCE(supply_amount, 0))                    AS totalSupplyAmount,
-            COUNT(*)                                            AS contractCount,
-            MAX(IFNULL(saved, 'N'))                            AS saved
-        FROM specific_item_flat
-        <include refid="commonWhere"/>
-        GROUP BY data_type, contract_no, vendor_biz_reg_no, demand_agency_name,
-                 contract_method, contract_type, item_category_no, detail_item_name, vendor_name
-        ORDER BY lastContractDate DESC
+            is_long_term                                        AS isLongTerm,
+            DATE_FORMAT(first_contract_date, '%Y-%m-%d')        AS firstContractDate,
+            DATE_FORMAT(last_contract_date, '%Y-%m-%d')         AS lastContractDate,
+            total_supply_amount                                 AS totalSupplyAmount,
+            contract_count                                      AS contractCount,
+            IFNULL(saved, 'N')                                  AS saved
+        FROM specific_item_grouped
+        <include refid="groupedWhere"/>
+        ORDER BY last_contract_date DESC, id
         LIMIT #{p.start}, #{p.length}
     </select>
 
     <select id="selectGroupedCount" resultType="int">
-        SELECT COUNT(*) FROM (
-            SELECT contract_no
-            FROM specific_item_flat
-            <include refid="commonWhere"/>
-            GROUP BY data_type, contract_no, vendor_biz_reg_no, demand_agency_name,
-                     contract_method, contract_type, item_category_no, detail_item_name, vendor_name
-        ) t
+        SELECT COUNT(*)
+        FROM specific_item_grouped
+        <include refid="groupedWhere"/>
     </select>
 
     <!-- ==================== SAVED ==================== -->
@@ -151,9 +181,20 @@
         UPDATE specific_item_flat
         SET saved = #{saved}
         WHERE contract_no = #{contractNo}
+        <if test="changeSeq != null">
+            AND change_seq = #{changeSeq}
+        </if>
         <if test="itemSeq != null">
             AND item_seq = #{itemSeq}
         </if>
+    </update>
+
+    <update id="updateGroupedSaved">
+        UPDATE specific_item_grouped
+        SET saved = #{saved}
+        WHERE data_type = #{dataType}
+          AND group_key = #{groupKey}
+          AND vendor_biz_reg_no &lt;=&gt; #{vendorBizRegNo}
     </update>
 
 </mapper>

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -15,6 +15,7 @@ import BidList from '../views/BidList.vue'
 import HomeView from '../views/HomeView.vue'
 import AboutView from '../views/AboutView.vue'
 import ReportGoodsView from '../views/ReportGoodsView.vue'
+import ReportSpecificItemView from '../views/ReportSpecificItemView.vue'
 import ReportShoppingMallView from '../views/ReportShoppingMallView.vue'
 import ReportDashboardView from '../views/ReportDashboardView.vue'
 import ReportServicesView from '../views/ReportServicesView.vue'
@@ -80,6 +81,12 @@ const router = createRouter({
       path: '/report-goods',
       name: 'report-goods',
       component: ReportGoodsView,
+      meta: { requiresAuth: true },
+    },
+    {
+      path: '/report-specific-item',
+      name: 'report-specific-item',
+      component: ReportSpecificItemView,
       meta: { requiresAuth: true },
     },
     {

--- a/frontend/src/views/ReportSpecificItemView.vue
+++ b/frontend/src/views/ReportSpecificItemView.vue
@@ -42,6 +42,10 @@
           <input type="checkbox" v-model="filters.showSavedOnly" />
           저장된 데이터만 보기
         </label>
+        <label v-if="!grouped" class="checkbox-label">
+          <input type="checkbox" v-model="filters.excellentOnly" />
+          우수제품만 보기
+        </label>
         <span class="actions-sep" aria-hidden="true"></span>
         <div class="long-term-toggle-wrap">
           <span class="long-term-toggle-label">장기계약 건</span>
@@ -255,10 +259,11 @@ const filters = reactive({
   rangeStart: '',
   rangeEnd: '',
   showSavedOnly: false,
+  excellentOnly: false,
 })
 
 function groupedRowKey(item) {
-  return `${item.contractNo || ''}_${item.vendorBizRegNo || ''}_${item.itemCategoryNo || ''}`
+  return `${item.dataType || ''}_${item.groupKey || ''}_${item.vendorBizRegNo || ''}`
 }
 
 function flatRowKey(item) {
@@ -283,6 +288,7 @@ function buildParams(includePaging = true) {
     rangeStart: filters.dateType === 'range' ? filters.rangeStart || undefined : undefined,
     rangeEnd: filters.dateType === 'range' ? filters.rangeEnd || undefined : undefined,
     showSavedOnly: filters.showSavedOnly,
+    isExcellentProduct: !grouped.value && filters.excellentOnly ? 'Y' : undefined,
   }
   if (includePaging) {
     p.start = (currentPage.value - 1) * PAGE_SIZE
@@ -363,8 +369,16 @@ const handleDownloadExcel = async () => {
 const toggleSave = async (item) => {
   const nextSaved = item.saved === 'Y' ? 'N' : 'Y'
   try {
-    const payload = { saved: nextSaved, contractNo: item.contractNo }
-    if (!grouped.value) payload.itemSeq = item.itemSeq
+    const payload = { saved: nextSaved, grouped: grouped.value }
+    if (grouped.value) {
+      payload.dataType = item.dataType
+      payload.groupKey = item.groupKey
+      payload.vendorBizRegNo = item.vendorBizRegNo
+    } else {
+      payload.contractNo = item.contractNo
+      payload.changeSeq = item.changeSeq
+      payload.itemSeq = item.itemSeq
+    }
     await axios.patch(API_BASE + '/saved', payload)
     item.saved = nextSaved
   } catch (e) {
@@ -384,6 +398,11 @@ watch(
   () => fetchData(true),
 )
 
+watch(
+  () => filters.excellentOnly,
+  () => fetchData(true),
+)
+
 onMounted(() => fetchData())
 </script>
 
@@ -391,7 +410,7 @@ onMounted(() => fetchData())
 .page-title {
   font-size: 1.4em;
   font-weight: 700;
-  color: #1e293b;
+  color: #ecf0f1;
   margin-bottom: 20px;
 }
 .search-container {

--- a/frontend/src/views/ReportSpecificItemView.vue
+++ b/frontend/src/views/ReportSpecificItemView.vue
@@ -1,0 +1,713 @@
+<template>
+  <LegacySidebarLayout>
+    <h1 class="page-title">특정품목 조달내역 (물품 · 쇼핑몰 통합)</h1>
+
+    <!-- 검색 필드 -->
+    <div class="search-container">
+      <div class="search-filter-row">
+        <!-- 데이터 구분 -->
+        <select v-model="filters.dataType" class="date-select">
+          <option value="">전체 (물품+쇼핑몰)</option>
+          <option value="general">물품(일반계약)</option>
+          <option value="shopping_mall">쇼핑몰(제3자단가)</option>
+        </select>
+
+        <input type="text" v-model="filters.demandAgencyName" placeholder="수요기관명 검색" />
+        <input type="text" v-model="filters.demandAgencyRegion" placeholder="수요기관지역 검색" />
+        <input type="text" v-model="filters.vendorBizRegNo" placeholder="사업자번호 검색" />
+        <input type="text" v-model="filters.itemCategoryNo" placeholder="물품분류번호 검색" />
+        <input type="text" v-model="filters.detailItemNo" placeholder="세부품명번호 검색" />
+
+        <select v-model="filters.dateType" class="date-select">
+          <option value="year">연도 검색</option>
+          <option value="month">특정 월 검색</option>
+          <option value="range">기간 검색</option>
+        </select>
+
+        <select v-if="filters.dateType === 'year'" v-model="filters.year" class="date-select">
+          <option value="">연도 선택</option>
+          <option v-for="y in years" :key="y" :value="y">{{ y }}</option>
+        </select>
+
+        <input v-if="filters.dateType === 'month'" type="month" v-model="filters.month" />
+
+        <template v-if="filters.dateType === 'range'">
+          <input type="month" v-model="filters.rangeStart" placeholder="시작월" />
+          <input type="month" v-model="filters.rangeEnd" placeholder="종료월" />
+        </template>
+      </div>
+
+      <div class="search-actions-row">
+        <label class="checkbox-label">
+          <input type="checkbox" v-model="filters.showSavedOnly" />
+          저장된 데이터만 보기
+        </label>
+        <span class="actions-sep" aria-hidden="true"></span>
+        <div class="long-term-toggle-wrap">
+          <span class="long-term-toggle-label">장기계약 건</span>
+          <button
+            type="button"
+            role="switch"
+            :aria-checked="grouped"
+            :title="grouped ? '합쳐서 보기' : '풀어서 보기'"
+            class="long-term-toggle-switch"
+            :class="{ on: grouped }"
+            @click="onToggleClick"
+          >
+            <span class="long-term-toggle-slider"></span>
+          </button>
+          <span class="long-term-toggle-caption">{{ grouped ? '합쳐서 보기' : '풀어서 보기' }}</span>
+        </div>
+
+        <button @click="handleSearch" class="search-btn">검색</button>
+        <button @click="handleDownloadExcel" class="excel-btn" :disabled="isLoadingExcel">
+          {{ isLoadingExcel ? '다운로드 중...' : '엑셀 다운로드' }}
+        </button>
+
+        <div v-if="isLoading" class="loading-spinner-container">
+          <div class="loading-spinner"></div>
+        </div>
+      </div>
+
+      <div v-if="isLoadingExcel" class="excel-download-overlay">
+        <div class="excel-download-progress">
+          <div class="excel-spinner"></div>
+          <p class="excel-progress-title">엑셀 생성 중</p>
+          <p class="excel-progress-desc">데이터가 많을 경우 10~30분 정도 걸릴 수 있습니다.</p>
+          <p class="excel-progress-hint">창을 닫지 마세요.</p>
+        </div>
+      </div>
+    </div>
+
+    <!-- 데이터 테이블 -->
+    <div class="table-container">
+      <div class="table-wrapper">
+        <table class="data-table">
+          <thead>
+            <!-- 합쳐서 보기 헤더 -->
+            <tr v-if="grouped">
+              <th>구분</th>
+              <th>업체명</th>
+              <th>사업자번호</th>
+              <th>수요기관명</th>
+              <th>수요기관지역</th>
+              <th>계약방법</th>
+              <th>계약유형</th>
+              <th>물품분류번호</th>
+              <th>세부품명</th>
+              <th>최초계약일자</th>
+              <th>최종계약일자</th>
+              <th>최종계약금액(합계)</th>
+              <th>계약건수</th>
+              <th>장기여부</th>
+              <th>저장</th>
+            </tr>
+            <!-- 풀어서 보기 헤더 -->
+            <tr v-else>
+              <th>구분</th>
+              <th>업체명</th>
+              <th>사업자번호</th>
+              <th>수요기관명</th>
+              <th>수요기관지역</th>
+              <th>계약방법</th>
+              <th>계약유형</th>
+              <th>물품분류번호</th>
+              <th>세부품명번호</th>
+              <th>세부품명</th>
+              <th>물품식별명</th>
+              <th>단위</th>
+              <th>단가</th>
+              <th>수량</th>
+              <th>공급금액</th>
+              <th>MAS</th>
+              <th>우수제품</th>
+              <th>직접구매</th>
+              <th>중기간경쟁</th>
+              <th>최초계약일자</th>
+              <th>계약일자</th>
+              <th>장기여부</th>
+              <th>저장</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-if="isLoading">
+              <td :colspan="grouped ? 15 : 23" class="loading-text">데이터를 불러오는 중입니다...</td>
+            </tr>
+            <tr v-else-if="items.length === 0">
+              <td :colspan="grouped ? 15 : 23" class="no-data">데이터가 없습니다.</td>
+            </tr>
+
+            <!-- 합쳐서 보기 행 -->
+            <template v-else-if="grouped">
+              <tr v-for="item in items" :key="groupedRowKey(item)">
+                <td>
+                  <span :class="dataTypeBadgeClass(item.dataType)" class="data-type-badge">
+                    {{ item.dataTypeLabel }}
+                  </span>
+                </td>
+                <td>{{ item.vendorName }}</td>
+                <td>{{ item.vendorBizRegNo }}</td>
+                <td>{{ item.demandAgencyName }}</td>
+                <td>{{ item.demandAgencyRegion }}</td>
+                <td>{{ item.contractMethod }}</td>
+                <td>{{ item.contractType }}</td>
+                <td>{{ item.itemCategoryNo }}</td>
+                <td>{{ item.detailItemName }}</td>
+                <td>{{ item.firstContractDate }}</td>
+                <td>{{ item.lastContractDate }}</td>
+                <td>{{ formatNumber(item.totalSupplyAmount) }}</td>
+                <td>{{ item.contractCount }}</td>
+                <td>{{ item.isLongTerm === 'Y' ? 'Y' : 'N' }}</td>
+                <td>
+                  <input type="checkbox" :checked="item.saved === 'Y'" @change="toggleSave(item)" />
+                </td>
+              </tr>
+            </template>
+
+            <!-- 풀어서 보기 행 -->
+            <template v-else>
+              <tr v-for="item in items" :key="flatRowKey(item)">
+                <td>
+                  <span :class="dataTypeBadgeClass(item.dataType)" class="data-type-badge">
+                    {{ item.dataTypeLabel }}
+                  </span>
+                </td>
+                <td>{{ item.vendorName }}</td>
+                <td>{{ item.vendorBizRegNo }}</td>
+                <td>{{ item.demandAgencyName }}</td>
+                <td>{{ item.demandAgencyRegion }}</td>
+                <td>{{ item.contractMethod }}</td>
+                <td>{{ item.contractType }}</td>
+                <td>{{ item.itemCategoryNo }}</td>
+                <td>{{ item.detailItemNo }}</td>
+                <td>{{ item.detailItemName }}</td>
+                <td>{{ item.itemIdentifierName }}</td>
+                <td>{{ item.unit }}</td>
+                <td>{{ formatNumber(item.unitPrice) }}</td>
+                <td>{{ formatNumber(item.quantity) }}</td>
+                <td>{{ formatNumber(item.supplyAmount) }}</td>
+                <td>{{ item.isMas }}</td>
+                <td>{{ item.isExcellentProduct }}</td>
+                <td>{{ item.isDirectPurchase }}</td>
+                <td>{{ item.isSmeCompetitive }}</td>
+                <td>{{ item.firstContractDate }}</td>
+                <td>{{ item.contractDate }}</td>
+                <td>{{ item.isLongTerm === 'Y' ? 'Y' : 'N' }}</td>
+                <td>
+                  <input type="checkbox" :checked="item.saved === 'Y'" @change="toggleSave(item)" />
+                </td>
+              </tr>
+            </template>
+          </tbody>
+        </table>
+      </div>
+
+      <div v-if="recordsFiltered > 0" class="pagination">
+        <span class="pagination-info">
+          {{ formatNumber(startDisplay) }}-{{ formatNumber(endDisplay) }} / {{ formatNumber(recordsFiltered) }}건
+        </span>
+        <button class="page-btn" :disabled="currentPage <= 1" @click="goPage(currentPage - 1)">이전</button>
+        <button
+          v-for="p in pageNumbers"
+          :key="p"
+          class="page-num-btn"
+          :class="{ active: p === currentPage }"
+          @click="goPage(p)"
+        >{{ p }}</button>
+        <button class="page-btn" :disabled="currentPage >= totalPages" @click="goPage(currentPage + 1)">다음</button>
+      </div>
+    </div>
+  </LegacySidebarLayout>
+</template>
+
+<script setup>
+import { ref, reactive, computed, onMounted, watch } from 'vue'
+import axios from 'axios'
+import LegacySidebarLayout from './components/LegacySidebarLayout.vue'
+
+const API_BASE = '/api/specific-item'
+const PAGE_SIZE = 100
+
+const isLoading = ref(false)
+const isLoadingExcel = ref(false)
+const items = ref([])
+const recordsFiltered = ref(0)
+const currentPage = ref(1)
+const grouped = ref(false)
+
+function onToggleClick() {
+  grouped.value = !grouped.value
+  fetchData(true)
+}
+
+const years = Array.from({ length: 10 }, (_, i) => String(2026 - i))
+
+const filters = reactive({
+  dataType: '',
+  demandAgencyName: '',
+  demandAgencyRegion: '',
+  vendorBizRegNo: '',
+  itemCategoryNo: '',
+  detailItemNo: '',
+  dateType: 'year',
+  year: '',
+  month: '',
+  rangeStart: '',
+  rangeEnd: '',
+  showSavedOnly: false,
+})
+
+function groupedRowKey(item) {
+  return `${item.contractNo || ''}_${item.vendorBizRegNo || ''}_${item.itemCategoryNo || ''}`
+}
+
+function flatRowKey(item) {
+  return `${item.contractNo || ''}_${item.changeSeq || ''}_${item.itemSeq ?? ''}`
+}
+
+function dataTypeBadgeClass(dataType) {
+  return dataType === 'shopping_mall' ? 'badge-shopping' : 'badge-general'
+}
+
+function buildParams(includePaging = true) {
+  const p = {
+    grouped: grouped.value,
+    dataType: filters.dataType || undefined,
+    demandAgencyName: filters.demandAgencyName || undefined,
+    demandAgencyRegion: filters.demandAgencyRegion || undefined,
+    vendorBizRegNo: filters.vendorBizRegNo || undefined,
+    itemCategoryNo: filters.itemCategoryNo || undefined,
+    detailItemNo: filters.detailItemNo || undefined,
+    year: filters.dateType === 'year' && filters.year ? parseInt(filters.year, 10) : undefined,
+    month: filters.dateType === 'month' ? filters.month || undefined : undefined,
+    rangeStart: filters.dateType === 'range' ? filters.rangeStart || undefined : undefined,
+    rangeEnd: filters.dateType === 'range' ? filters.rangeEnd || undefined : undefined,
+    showSavedOnly: filters.showSavedOnly,
+  }
+  if (includePaging) {
+    p.start = (currentPage.value - 1) * PAGE_SIZE
+    p.length = PAGE_SIZE
+  }
+  return p
+}
+
+const totalPages = computed(() => Math.max(1, Math.ceil(recordsFiltered.value / PAGE_SIZE)))
+const startDisplay = computed(() =>
+  recordsFiltered.value === 0 ? 0 : (currentPage.value - 1) * PAGE_SIZE + 1,
+)
+const endDisplay = computed(() => Math.min(currentPage.value * PAGE_SIZE, recordsFiltered.value))
+const pageNumbers = computed(() => {
+  const total = totalPages.value
+  if (total <= 10) return Array.from({ length: total }, (_, i) => i + 1)
+  const cur = currentPage.value
+  let start = Math.max(1, cur - 4)
+  let end = Math.min(total, start + 9)
+  if (end - start < 9) start = Math.max(1, end - 9)
+  return Array.from({ length: end - start + 1 }, (_, i) => start + i)
+})
+
+const fetchData = async (resetPage = false) => {
+  if (resetPage) currentPage.value = 1
+  isLoading.value = true
+  try {
+    const { data } = await axios.get(API_BASE, { params: buildParams(true) })
+    items.value = Array.isArray(data.data) ? data.data : []
+    recordsFiltered.value = data.recordsFiltered ?? items.value.length
+  } catch (e) {
+    console.error('특정품목 조회 실패', e)
+    items.value = []
+    recordsFiltered.value = 0
+  } finally {
+    isLoading.value = false
+  }
+}
+
+const goPage = (page) => {
+  const total = Math.max(1, Math.ceil(recordsFiltered.value / PAGE_SIZE))
+  if (page < 1 || page > total) return
+  currentPage.value = page
+  fetchData()
+}
+
+const handleSearch = () => fetchData(true)
+
+const handleDownloadExcel = async () => {
+  isLoadingExcel.value = true
+  try {
+    const params = new URLSearchParams()
+    Object.entries(buildParams(false)).forEach(([k, v]) => {
+      if (v !== undefined && v !== '') params.append(k, v)
+    })
+    const { data } = await axios.get(API_BASE + '/excel?' + params.toString(), {
+      responseType: 'blob',
+      timeout: 1800000,
+    })
+    const url = URL.createObjectURL(new Blob([data]))
+    const a = document.createElement('a')
+    a.href = url
+    a.download = `specific_item_${Date.now()}.xlsx`
+    a.click()
+    URL.revokeObjectURL(url)
+  } catch (e) {
+    console.error('엑셀 다운로드 실패', e)
+    alert(
+      e?.code === 'ECONNABORTED'
+        ? '요청 시간이 초과되었습니다. 조건을 줄이거나 다시 시도해 주세요.'
+        : '엑셀 다운로드에 실패했습니다.',
+    )
+  } finally {
+    isLoadingExcel.value = false
+  }
+}
+
+const toggleSave = async (item) => {
+  const nextSaved = item.saved === 'Y' ? 'N' : 'Y'
+  try {
+    const payload = { saved: nextSaved, contractNo: item.contractNo }
+    if (!grouped.value) payload.itemSeq = item.itemSeq
+    await axios.patch(API_BASE + '/saved', payload)
+    item.saved = nextSaved
+  } catch (e) {
+    console.error('저장 여부 업데이트 실패', e)
+    alert('저장 상태 변경에 실패했습니다.')
+  }
+}
+
+const formatNumber = (num) => {
+  if (num == null) return ''
+  const n = typeof num === 'number' ? num : Number(num)
+  return isNaN(n) ? String(num) : n.toLocaleString()
+}
+
+watch(
+  () => filters.showSavedOnly,
+  () => fetchData(true),
+)
+
+onMounted(() => fetchData())
+</script>
+
+<style scoped>
+.page-title {
+  font-size: 1.4em;
+  font-weight: 700;
+  color: #1e293b;
+  margin-bottom: 20px;
+}
+.search-container {
+  margin-bottom: 24px;
+  padding: 18px 20px;
+  background: #f8fafc;
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: flex-start;
+}
+.search-filter-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px 12px;
+  flex: 1 1 100%;
+  min-width: 0;
+  justify-content: flex-end;
+}
+.search-filter-row input[type='text'],
+.search-filter-row select,
+.search-filter-row input[type='month'] {
+  min-width: 100px;
+}
+.search-actions-row {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 12px;
+  flex: 1 1 100%;
+  margin-top: 10px;
+  padding-top: 10px;
+  border-top: 1px solid #e2e8f0;
+}
+input[type='text'],
+select,
+input[type='month'] {
+  padding: 10px 12px;
+  border: 1px solid #cbd5e1;
+  border-radius: 8px;
+  font-size: 0.9375em;
+  min-width: 120px;
+  transition: border-color 0.2s;
+}
+input[type='text']:focus,
+select:focus,
+input[type='month']:focus {
+  outline: none;
+  border-color: #3498db;
+}
+.search-btn {
+  padding: 10px 18px;
+  background: linear-gradient(180deg, #3d5a73 0%, #34495e 100%);
+  color: #f0f4f8;
+  border: none;
+  cursor: pointer;
+  border-radius: 8px;
+  font-weight: 500;
+  font-size: 0.9375em;
+}
+.search-btn:hover {
+  opacity: 0.95;
+}
+.excel-btn {
+  padding: 10px 18px;
+  background: linear-gradient(180deg, #2e8b5e 0%, #27ae60 100%);
+  color: #fff;
+  border: none;
+  cursor: pointer;
+  border-radius: 8px;
+  font-weight: 500;
+  font-size: 0.9375em;
+}
+.excel-btn:hover:not(:disabled) {
+  opacity: 0.95;
+}
+.excel-btn:disabled {
+  opacity: 0.65;
+  cursor: not-allowed;
+}
+.excel-download-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 9999;
+}
+.excel-download-progress {
+  background: #fff;
+  padding: 28px 36px;
+  border-radius: 12px;
+  text-align: center;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
+}
+.excel-spinner {
+  width: 48px;
+  height: 48px;
+  margin: 0 auto 16px;
+  border: 4px solid #ecf0f1;
+  border-top: 4px solid #27ae60;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+}
+.excel-progress-title {
+  font-size: 18px;
+  font-weight: 600;
+  margin: 0 0 8px;
+  color: #2c3e50;
+}
+.excel-progress-desc {
+  font-size: 14px;
+  color: #7f8c8d;
+  margin: 0 0 4px;
+}
+.excel-progress-hint {
+  font-size: 12px;
+  color: #95a5a6;
+  margin: 0;
+}
+.checkbox-label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+  font-size: 0.9em;
+  color: #475569;
+}
+.actions-sep {
+  display: inline-block;
+  width: 1px;
+  height: 18px;
+  margin: 0 4px;
+  background: #cbd5e1;
+  opacity: 0.7;
+  border-radius: 1px;
+  flex-shrink: 0;
+}
+.long-term-toggle-wrap {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.long-term-toggle-label {
+  font-size: 0.875em;
+  font-weight: 500;
+  color: #475569;
+}
+.long-term-toggle-switch {
+  position: relative;
+  width: 44px;
+  height: 24px;
+  border: 1px solid #cbd5e1;
+  border-radius: 24px;
+  background: #e2e8f0;
+  cursor: pointer;
+  padding: 0;
+  transition: background 0.2s, border-color 0.2s;
+}
+.long-term-toggle-switch:hover {
+  border-color: #94a3b8;
+}
+.long-term-toggle-switch.on {
+  background: #3498db;
+  border-color: #3498db;
+}
+.long-term-toggle-slider {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: #fff;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.15);
+  transition: transform 0.2s;
+}
+.long-term-toggle-switch.on .long-term-toggle-slider {
+  transform: translateX(20px);
+}
+.long-term-toggle-caption {
+  font-size: 0.8125em;
+  color: #64748b;
+}
+.loading-spinner-container {
+  margin-left: 10px;
+}
+.loading-spinner {
+  width: 24px;
+  height: 24px;
+  border: 4px solid #f3f3f3;
+  border-top: 4px solid #3498db;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+}
+@keyframes spin {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+}
+.table-container {
+  overflow-x: auto;
+  margin-top: 4px;
+}
+.data-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+.data-table th,
+.data-table td {
+  padding: 12px 10px;
+  border: 1px solid #e2e8f0;
+  text-align: center;
+  font-size: 0.9em;
+}
+.data-table th {
+  background: #f1f5f9;
+  font-weight: 600;
+  color: #334155;
+}
+.data-table tbody tr:nth-child(even) {
+  background-color: #fafbfc;
+}
+.data-table tbody tr:hover {
+  background-color: #f1f5f9;
+}
+.loading-text,
+.no-data {
+  text-align: center;
+  padding: 24px;
+  color: #64748b;
+  font-size: 0.95em;
+}
+.table-wrapper {
+  max-height: 70vh;
+  overflow: auto;
+  border: 1px solid #e2e8f0;
+  border-radius: 10px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
+}
+.data-table th {
+  position: sticky;
+  top: 0;
+  background: #f1f5f9;
+  z-index: 1;
+}
+.data-table th,
+.data-table td {
+  white-space: nowrap;
+}
+.pagination {
+  margin-top: 16px;
+  padding: 14px 0;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+.pagination-info {
+  margin-right: 14px;
+  font-size: 0.9em;
+  color: #64748b;
+}
+.page-btn {
+  padding: 8px 14px;
+  border: 1px solid #e2e8f0;
+  background: #fff;
+  cursor: pointer;
+  border-radius: 8px;
+  font-size: 0.9em;
+  transition: background 0.2s, border-color 0.2s;
+}
+.page-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+.page-btn:not(:disabled):hover {
+  background: #f1f5f9;
+  border-color: #cbd5e1;
+}
+.page-num-btn {
+  min-width: 38px;
+  padding: 8px 10px;
+  border: 1px solid #e2e8f0;
+  background: #fff;
+  cursor: pointer;
+  border-radius: 8px;
+  font-size: 0.9em;
+  transition: background 0.2s, border-color 0.2s;
+}
+.page-num-btn:hover {
+  background: #f1f5f9;
+  border-color: #cbd5e1;
+}
+.page-num-btn.active {
+  background: linear-gradient(180deg, #3d5a73 0%, #34495e 100%);
+  color: #fff;
+  border-color: #34495e;
+}
+.data-type-badge {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 12px;
+  font-size: 0.78em;
+  font-weight: 600;
+  white-space: nowrap;
+}
+.badge-general {
+  background: #dbeafe;
+  color: #1d4ed8;
+}
+.badge-shopping {
+  background: #dcfce7;
+  color: #15803d;
+}
+</style>

--- a/frontend/src/views/components/LegacySidebarLayout.vue
+++ b/frontend/src/views/components/LegacySidebarLayout.vue
@@ -40,6 +40,9 @@
           <span class="menu-label">보고서 데이터</span>
         </li>
         <ul v-show="isReportSubmenuOpen" class="submenu" style="padding-left: 20px">
+          <li class="menu-item" @click="$router.push('/report-specific-item')">
+            <span class="menu-label">특정품목 (물품·쇼핑몰 통합)</span>
+          </li>
           <li class="menu-item" @click="$router.push('/report-goods')">
             <span class="menu-label">물품</span>
           </li>


### PR DESCRIPTION
## 변경 사항

### 장기계약 묶음(grouped) 재설계
- `specific_item_grouped` 물리 테이블 신설 (V14) — 초년도계약번호(`first_year_contract_no`) 기준으로 장기계속계약 연차를 1행으로 묶음
- grouped 조회를 실시간 GROUP BY → 사전집계 테이블 단순조회로 전환 (**155s → 0.08s**)
- 단기/단일계약은 그대로 1행, 장기계약만 병합

### ETL 개선
- `is_final_contract = 'Y'` 필터 추가 (각 연차 최종 확정 건만 flat 적재)
- `is_long_term` 판정 버그 수정 — "신규(단기)" 11만건이 장기로 오분류되던 문제 해결 (신규(장기)/장기/계속비만 Y)
- `first_year_contract_no` 컬럼 flat 추가 (V13)
- flat 적재 후 grouped 재집계 단계 추가, **재집계 시 saved 보존**

### 저장(saved) 기능
- grouped 테이블 자체 saved 컬럼으로 묶음 단위 독립 관리
- 저장 API를 grouped/flat 분기 처리

### 프론트
- '우수제품만 보기' 필터 추가 (풀어서 보기 전용)
- grouped 저장 시 group_key 기준 전송

## 검증 (로컬)
- 충북1지구 장기계약: 4연차 → 1행, 합산 3,026,868,000원 (기존 시스템과 일치)
- grouped 430,320행, 조회 0.08초
- 우수제품 필터 200,379건 전부 Y 확인

## 서버 배포 시 주의
- Flyway V13·V14 자동 적용 후 ETL 재실행 필요 (flat 재적재 → grouped 집계)

🤖 Generated with [Claude Code](https://claude.com/claude-code)