### PR TITLE
G2B-17 feat: 특정품목 통합 페이지 기본화면 설정 및 조회 성능 개선

### DIFF
--- a/backend/src/main/resources/db/migration/V15__add_specific_item_flat_list_order_index.sql
+++ b/backend/src/main/resources/db/migration/V15__add_specific_item_flat_list_order_index.sql
@@ -1,0 +1,7 @@
+-- 특정품목 통합 조회(풀어서 보기) 기본 정렬/필터 성능 개선
+-- selectFlatList: WHERE is_active='Y' ORDER BY contract_date DESC, contract_no, item_seq LIMIT
+-- selectFlatCount: WHERE is_active='Y'
+-- 위 두 쿼리가 풀 테이블 스캔 + filesort(821k행)를 수행하던 것을
+-- (is_active, contract_date DESC, contract_no, item_seq) 복합 인덱스로 커버링 처리.
+CREATE INDEX idx_flat_list_order
+    ON specific_item_flat (is_active, contract_date DESC, contract_no ASC, item_seq ASC);

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -74,7 +74,7 @@ const router = createRouter({
       name: 'main',
       redirect: () => {
         const store = useAuthStore()
-        return store.isLoggedIn ? '/report-goods' : '/login'
+        return store.isLoggedIn ? '/report-specific-item' : '/login'
       },
     },
     {

--- a/frontend/src/views/auth/LoginView.vue
+++ b/frontend/src/views/auth/LoginView.vue
@@ -61,7 +61,7 @@ const handleLogin = async () => {
   try {
     await authStore.login(username.value, password.value)
     await authStore.fetchMe()
-    const redirect = route.query.redirect || '/report-goods'
+    const redirect = route.query.redirect || '/report-specific-item'
     router.push(redirect)
   } catch (e) {
     const code = e.response?.data?.code


### PR DESCRIPTION
## 변경 사항

### 1. 기본 진입 페이지 변경
- 로그인 후 진입 페이지를 `/report-goods` → `/report-specific-item`로 변경
- `router/index.js` redirect + `auth/LoginView.vue` 기본 이동 경로

### 2. 조회 성능 개선 (V15)
- `specific_item_flat` 풀어서 보기 기본 조회가 821k행 풀스캔 + filesort 수행하던 문제
- 복합 인덱스 `idx_flat_list_order (is_active, contract_date DESC, contract_no ASC, item_seq ASC)` 추가
- WHERE 필터 + ORDER BY + COUNT를 단일 커버링 인덱스로 처리

## 성능 (로컬)
- list 쿼리: 0.93s → 0.013s
- count 쿼리: 1.09s → 0.146s
- API 응답(인증 포함): ~0.34s

🔗 G2B-17

🤖 Generated with [Claude Code](https://claude.com/claude-code)