### PR TITLE
G2B-18 perf: 우수제품 필터 조회 성능 개선용 전용 인덱스 추가

### DIFF
--- a/backend/src/main/resources/db/migration/V16__add_specific_item_flat_excellent_index.sql
+++ b/backend/src/main/resources/db/migration/V16__add_specific_item_flat_excellent_index.sql
@@ -1,0 +1,6 @@
+-- 특정품목 통합 조회(풀어서 보기) '우수제품만 보기' 필터 성능 개선
+-- WHERE is_active='Y' AND is_excellent_product='Y' ORDER BY contract_date DESC, contract_no, item_seq
+-- 기존 idx_flat_list_order에는 is_excellent_product가 없어 count가 87만 엔트리 전체를 필터링(약 1.47s).
+-- is_excellent_product를 정렬키 앞에 둔 전용 복합 인덱스로 count/list를 커버링 처리.
+CREATE INDEX idx_flat_excellent_order
+    ON specific_item_flat (is_active, is_excellent_product, contract_date DESC, contract_no ASC, item_seq ASC);


### PR DESCRIPTION
## 변경 사항
풀어서 보기 '우수제품만 보기' 체크 시 count 쿼리가 `idx_flat_list_order`로 87만 엔트리 전체를 필터링하며 약 1.47s 소요.

`is_excellent_product`를 정렬키 앞에 둔 복합 인덱스 `idx_flat_excellent_order (is_active, is_excellent_product, contract_date DESC, contract_no ASC, item_seq ASC)` 추가 (V16).

## 성능 (로컬)
- count: 1.474s → 0.046s (Using index)
- 우수제품 API 응답(웜): ~0.06s
- 기본(필터 없음) 조회: 기존 idx_flat_list_order 유지 → 영향 없음

🔗 G2B-18

🤖 Generated with [Claude Code](https://claude.com/claude-code)