### PR TITLE
G2B-19 fix: 특정품목 엑셀 다운로드 OOM(500) 수정 및 스트리밍 처리

### DIFF
--- a/backend/src/main/java/org/example/g2bplatform/controller/SpecificItemController.java
+++ b/backend/src/main/java/org/example/g2bplatform/controller/SpecificItemController.java
@@ -20,6 +20,7 @@ public class SpecificItemController {
 
     private final SpecificItemEtlService etlService;
     private final SpecificItemMapper specificItemMapper;
+    private final org.apache.ibatis.session.SqlSessionFactory sqlSessionFactory;
 
     /** ETL 실행 — SUPER_ADMIN 전용, 비동기 Job 반환 */
     @PostMapping("/api/admin/etl/specific-item")
@@ -79,9 +80,13 @@ public class SpecificItemController {
         return ResponseEntity.ok().build();
     }
 
-    /** 엑셀 다운로드 */
+    /**
+     * 엑셀 다운로드 — 대용량 대응.
+     * DB 결과를 MyBatis Cursor로 스트리밍하고 SXSSFWorkbook(윈도우 플러시)으로 생성,
+     * StreamingResponseBody로 응답에 직접 흘려보내 전체 List/Workbook 메모리 적재를 피한다.
+     */
     @GetMapping("/api/specific-item/excel")
-    public ResponseEntity<byte[]> excel(
+    public ResponseEntity<org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody> excel(
             @RequestParam(required = false) String dataType,
             @RequestParam(required = false) String demandAgencyName,
             @RequestParam(required = false) String demandAgencyRegion,
@@ -102,15 +107,13 @@ public class SpecificItemController {
                 itemCategoryNo, detailItemNo, isMas, isExcellentProduct,
                 year, month, rangeStart, rangeEnd, showSavedOnly, grouped, 0, Integer.MAX_VALUE);
 
-        List<Map<String, Object>> rows = grouped
-                ? specificItemMapper.selectGroupedList(params)
-                : specificItemMapper.selectFlatList(params);
+        org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody body =
+                out -> writeExcel(out, params, grouped);
 
-        byte[] xlsx = buildExcel(rows, grouped);
         return ResponseEntity.ok()
                 .header("Content-Disposition", "attachment; filename=\"specific_item.xlsx\"")
                 .header("Content-Type", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")
-                .body(xlsx);
+                .body(body);
     }
 
     private Map<String, Object> buildParams(
@@ -141,8 +144,11 @@ public class SpecificItemController {
 
     private boolean ne(String v) { return v != null && !v.isBlank(); }
 
-    private byte[] buildExcel(List<Map<String, Object>> rows, boolean grouped) {
-        try (org.apache.poi.xssf.usermodel.XSSFWorkbook wb = new org.apache.poi.xssf.usermodel.XSSFWorkbook()) {
+    private void writeExcel(java.io.OutputStream out, Map<String, Object> params, boolean grouped) throws java.io.IOException {
+        // SXSSF: 메모리에 최근 100행만 유지하고 나머지는 임시파일로 플러시
+        org.apache.poi.xssf.streaming.SXSSFWorkbook wb = new org.apache.poi.xssf.streaming.SXSSFWorkbook(100);
+        wb.setCompressTempFiles(true);
+        try {
             org.apache.poi.ss.usermodel.Sheet sheet = wb.createSheet("특정품목");
             String[] headers = grouped
                     ? new String[]{"구분","업체명","사업자번호","수요기관명","수요기관지역","계약유형","물품분류번호","세부품명","최초계약일자","최종계약일자","최종계약금액(합계)","계약건수","장기여부","저장"}
@@ -152,61 +158,77 @@ public class SpecificItemController {
             for (int i = 0; i < headers.length; i++) header.createCell(i).setCellValue(headers[i]);
 
             int rowIdx = 1;
-            for (Map<String, Object> r : rows) {
-                org.apache.poi.ss.usermodel.Row row = sheet.createRow(rowIdx++);
-                if (grouped) {
-                    setCell(row, 0, r.get("dataTypeLabel"));
-                    setCell(row, 1, r.get("vendorName"));
-                    setCell(row, 2, r.get("vendorBizRegNo"));
-                    setCell(row, 3, r.get("demandAgencyName"));
-                    setCell(row, 4, r.get("demandAgencyRegion"));
-                    setCell(row, 5, r.get("contractType"));
-                    setCell(row, 6, r.get("itemCategoryNo"));
-                    setCell(row, 7, r.get("detailItemName"));
-                    setCell(row, 8, r.get("firstContractDate"));
-                    setCell(row, 9, r.get("lastContractDate"));
-                    setCell(row, 10, r.get("totalSupplyAmount"));
-                    setCell(row, 11, r.get("contractCount"));
-                    setCell(row, 12, r.get("isLongTerm"));
-                    setCell(row, 13, r.get("saved"));
-                } else {
-                    setCell(row, 0, r.get("dataTypeLabel"));
-                    setCell(row, 1, r.get("vendorName"));
-                    setCell(row, 2, r.get("vendorBizRegNo"));
-                    setCell(row, 3, r.get("demandAgencyName"));
-                    setCell(row, 4, r.get("demandAgencyRegion"));
-                    setCell(row, 5, r.get("contractMethod"));
-                    setCell(row, 6, r.get("contractType"));
-                    setCell(row, 7, r.get("itemCategoryNo"));
-                    setCell(row, 8, r.get("detailItemNo"));
-                    setCell(row, 9, r.get("detailItemName"));
-                    setCell(row, 10, r.get("itemIdentifierName"));
-                    setCell(row, 11, r.get("unit"));
-                    setCell(row, 12, r.get("unitPrice"));
-                    setCell(row, 13, r.get("quantity"));
-                    setCell(row, 14, r.get("supplyAmount"));
-                    setCell(row, 15, r.get("isMas"));
-                    setCell(row, 16, r.get("isExcellentProduct"));
-                    setCell(row, 17, r.get("isDirectPurchase"));
-                    setCell(row, 18, r.get("isSmeCompetitive"));
-                    setCell(row, 19, r.get("firstContractDate"));
-                    setCell(row, 20, r.get("contractDate"));
-                    setCell(row, 21, r.get("isLongTerm"));
-                    setCell(row, 22, r.get("saved"));
+            // 스트리밍 람다는 컨트롤러 트랜잭션 밖(비동기)에서 실행되므로 전용 SqlSession을 직접 연다.
+            try (org.apache.ibatis.session.SqlSession session = sqlSessionFactory.openSession();
+                 org.apache.ibatis.cursor.Cursor<Map<String, Object>> cursor =
+                         grouped ? session.getMapper(SpecificItemMapper.class).selectGroupedListExport(params)
+                                 : session.getMapper(SpecificItemMapper.class).selectFlatListExport(params)) {
+                for (Map<String, Object> r : cursor) {
+                    org.apache.poi.ss.usermodel.Row row = sheet.createRow(rowIdx++);
+                    if (grouped) writeGroupedRow(row, r);
+                    else writeFlatRow(row, r);
                 }
             }
-            java.io.ByteArrayOutputStream out = new java.io.ByteArrayOutputStream();
             wb.write(out);
-            return out.toByteArray();
         } catch (Exception e) {
-            throw new RuntimeException("엑셀 생성 실패", e);
+            throw new java.io.IOException("엑셀 생성 실패", e);
+        } finally {
+            wb.dispose(); // 임시파일 정리
+            wb.close();
         }
     }
 
+    private void writeGroupedRow(org.apache.poi.ss.usermodel.Row row, Map<String, Object> r) {
+        setCell(row, 0, r.get("dataTypeLabel"));
+        setCell(row, 1, r.get("vendorName"));
+        setCell(row, 2, r.get("vendorBizRegNo"));
+        setCell(row, 3, r.get("demandAgencyName"));
+        setCell(row, 4, r.get("demandAgencyRegion"));
+        setCell(row, 5, r.get("contractType"));
+        setCell(row, 6, r.get("itemCategoryNo"));
+        setCell(row, 7, r.get("detailItemName"));
+        setCell(row, 8, r.get("firstContractDate"));
+        setCell(row, 9, r.get("lastContractDate"));
+        setCell(row, 10, r.get("totalSupplyAmount"));
+        setCell(row, 11, r.get("contractCount"));
+        setCell(row, 12, r.get("isLongTerm"));
+        setCell(row, 13, r.get("saved"));
+    }
+
+    private void writeFlatRow(org.apache.poi.ss.usermodel.Row row, Map<String, Object> r) {
+        setCell(row, 0, r.get("dataTypeLabel"));
+        setCell(row, 1, r.get("vendorName"));
+        setCell(row, 2, r.get("vendorBizRegNo"));
+        setCell(row, 3, r.get("demandAgencyName"));
+        setCell(row, 4, r.get("demandAgencyRegion"));
+        setCell(row, 5, r.get("contractMethod"));
+        setCell(row, 6, r.get("contractType"));
+        setCell(row, 7, r.get("itemCategoryNo"));
+        setCell(row, 8, r.get("detailItemNo"));
+        setCell(row, 9, r.get("detailItemName"));
+        setCell(row, 10, r.get("itemIdentifierName"));
+        setCell(row, 11, r.get("unit"));
+        setCell(row, 12, r.get("unitPrice"));
+        setCell(row, 13, r.get("quantity"));
+        setCell(row, 14, r.get("supplyAmount"));
+        setCell(row, 15, r.get("isMas"));
+        setCell(row, 16, r.get("isExcellentProduct"));
+        setCell(row, 17, r.get("isDirectPurchase"));
+        setCell(row, 18, r.get("isSmeCompetitive"));
+        setCell(row, 19, r.get("firstContractDate"));
+        setCell(row, 20, r.get("contractDate"));
+        setCell(row, 21, r.get("isLongTerm"));
+        setCell(row, 22, r.get("saved"));
+    }
+
     private void setCell(org.apache.poi.ss.usermodel.Row row, int col, Object val) {
-        org.apache.poi.ss.usermodel.Cell cell = row.createCell(col);
-        if (val == null) { cell.setCellValue(""); return; }
-        if (val instanceof Number) cell.setCellValue(((Number) val).doubleValue());
-        else cell.setCellValue(val.toString());
+        // null/빈값은 셀 자체를 만들지 않아 대용량 export 시 셀 생성 비용 절감
+        if (val == null) return;
+        if (val instanceof Number) {
+            row.createCell(col).setCellValue(((Number) val).doubleValue());
+        } else {
+            String s = val.toString();
+            if (!s.isEmpty()) row.createCell(col).setCellValue(s);
+        }
     }
 }

--- a/backend/src/main/java/org/example/g2bplatform/mapper/SpecificItemMapper.java
+++ b/backend/src/main/java/org/example/g2bplatform/mapper/SpecificItemMapper.java
@@ -2,6 +2,7 @@ package org.example.g2bplatform.mapper;
 
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
+import org.apache.ibatis.cursor.Cursor;
 
 import java.util.List;
 import java.util.Map;
@@ -13,9 +14,15 @@ public interface SpecificItemMapper {
 
     int selectFlatCount(@Param("p") Map<String, Object> params);
 
+    /** 엑셀 export 전용 — 전체 행을 스트리밍으로 반환 (열린 SqlSession 내에서 순회) */
+    Cursor<Map<String, Object>> selectFlatListExport(@Param("p") Map<String, Object> params);
+
     List<Map<String, Object>> selectGroupedList(@Param("p") Map<String, Object> params);
 
     int selectGroupedCount(@Param("p") Map<String, Object> params);
+
+    /** 엑셀 export 전용 — 전체 행을 스트리밍으로 반환 */
+    Cursor<Map<String, Object>> selectGroupedListExport(@Param("p") Map<String, Object> params);
 
     void updateSaved(Map<String, Object> params);
 

--- a/backend/src/main/resources/org/example/g2bplatform/mapper/SpecificItemMapper.xml
+++ b/backend/src/main/resources/org/example/g2bplatform/mapper/SpecificItemMapper.xml
@@ -105,6 +105,37 @@
         <include refid="commonWhere"/>
     </select>
 
+    <!-- 엑셀 export 전용: LIMIT 없이 전체를 스트리밍(fetchSize=Integer.MIN_VALUE)으로 -->
+    <select id="selectFlatListExport" resultType="map" fetchSize="-2147483648" resultSetType="FORWARD_ONLY">
+        SELECT
+            <include refid="dataTypeLabel"/>,
+            vendor_name                                         AS vendorName,
+            vendor_biz_reg_no                                   AS vendorBizRegNo,
+            demand_agency_name                                  AS demandAgencyName,
+            demand_agency_region                                AS demandAgencyRegion,
+            contract_method                                     AS contractMethod,
+            contract_type                                       AS contractType,
+            item_category_no                                    AS itemCategoryNo,
+            detail_item_no                                      AS detailItemNo,
+            detail_item_name                                    AS detailItemName,
+            item_identifier_name                                AS itemIdentifierName,
+            unit                                                AS unit,
+            unit_price                                          AS unitPrice,
+            quantity                                            AS quantity,
+            supply_amount                                       AS supplyAmount,
+            is_mas                                              AS isMas,
+            is_excellent_product                                AS isExcellentProduct,
+            is_direct_purchase                                  AS isDirectPurchase,
+            is_sme_competitive                                  AS isSmeCompetitive,
+            DATE_FORMAT(first_contract_date, '%Y-%m-%d')        AS firstContractDate,
+            DATE_FORMAT(contract_date, '%Y-%m-%d')              AS contractDate,
+            is_long_term                                        AS isLongTerm,
+            IFNULL(saved, 'N')                                  AS saved
+        FROM specific_item_flat
+        <include refid="commonWhere"/>
+        ORDER BY contract_date DESC, contract_no, item_seq
+    </select>
+
     <!-- ==================== GROUPED ==================== -->
 
     <sql id="groupedWhere">
@@ -173,6 +204,28 @@
         SELECT COUNT(*)
         FROM specific_item_grouped
         <include refid="groupedWhere"/>
+    </select>
+
+    <!-- 엑셀 export 전용: LIMIT 없이 전체를 스트리밍으로 -->
+    <select id="selectGroupedListExport" resultType="map" fetchSize="-2147483648" resultSetType="FORWARD_ONLY">
+        SELECT
+            <include refid="dataTypeLabel"/>,
+            vendor_name                                         AS vendorName,
+            vendor_biz_reg_no                                   AS vendorBizRegNo,
+            demand_agency_name                                  AS demandAgencyName,
+            demand_agency_region                                AS demandAgencyRegion,
+            contract_type                                       AS contractType,
+            item_category_no                                    AS itemCategoryNo,
+            detail_item_name                                    AS detailItemName,
+            DATE_FORMAT(first_contract_date, '%Y-%m-%d')        AS firstContractDate,
+            DATE_FORMAT(last_contract_date, '%Y-%m-%d')         AS lastContractDate,
+            total_supply_amount                                 AS totalSupplyAmount,
+            contract_count                                      AS contractCount,
+            is_long_term                                        AS isLongTerm,
+            IFNULL(saved, 'N')                                  AS saved
+        FROM specific_item_grouped
+        <include refid="groupedWhere"/>
+        ORDER BY last_contract_date DESC, id
     </select>
 
     <!-- ==================== SAVED ==================== -->


### PR DESCRIPTION
## 문제
특정품목 통합 페이지 엑셀 다운로드 시 500 — 서버 로그 `java.lang.OutOfMemoryError: Java heap space`.
원인: `LIMIT 0, Integer.MAX_VALUE`로 87만 행 전체를 List 적재 후 XSSFWorkbook(전체 메모리 보관)으로 생성 → 힙(2GB) 초과.

## 조치
- DB 결과를 MyBatis `Cursor`(fetchSize 스트리밍)로 순회 — 전체 List 적재 제거
- 스트리밍 람다는 컨트롤러 트랜잭션 밖(비동기)에서 실행되므로 전용 `SqlSession`을 람다 내에서 직접 open
- `XSSFWorkbook` → `SXSSFWorkbook`(윈도우 100, 임시파일 압축)
- `StreamingResponseBody`로 응답 직접 스트리밍, null 셀 생성 생략

## 검증 (로컬)
| 모드 | 행수 | 이전 | 현재 |
|------|------|------|------|
| 풀어서 보기 | 870,753 | 500 실패 | 200 성공 52s |
| 묶어서 보기 | 430,320 | — | 17s |
| 우수제품만 | 200,379 | — | 12s |
- OOM 0건, 컨테이너 메모리 930MB 안정, xlsx 파일 유효성 확인

🔗 G2B-19

🤖 Generated with [Claude Code](https://claude.com/claude-code)