### PR TITLE
G2B-19 fix: 엑셀 다운로드 비동기 응답 제거 (AccessDenied 회피)

### DIFF
--- a/backend/src/main/java/org/example/g2bplatform/controller/SpecificItemController.java
+++ b/backend/src/main/java/org/example/g2bplatform/controller/SpecificItemController.java
@@ -81,12 +81,13 @@ public class SpecificItemController {
     }
 
     /**
-     * 엑셀 다운로드 — 대용량 대응.
-     * DB 결과를 MyBatis Cursor로 스트리밍하고 SXSSFWorkbook(윈도우 플러시)으로 생성,
-     * StreamingResponseBody로 응답에 직접 흘려보내 전체 List/Workbook 메모리 적재를 피한다.
+     * 엑셀 다운로드 — 대용량 대응(동기).
+     * DB 결과를 MyBatis Cursor로 스트리밍하고 SXSSFWorkbook(윈도우 플러시)으로 생성해
+     * 전체 List/Workbook 메모리 적재를 피한다. 요청 스레드에서 동기로 생성하므로
+     * (StreamingResponseBody 비동기 재디스패치 시 Spring Security AccessDenied 회피) 보안 필터가 정상 동작한다.
      */
     @GetMapping("/api/specific-item/excel")
-    public ResponseEntity<org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody> excel(
+    public ResponseEntity<byte[]> excel(
             @RequestParam(required = false) String dataType,
             @RequestParam(required = false) String demandAgencyName,
             @RequestParam(required = false) String demandAgencyRegion,
@@ -101,19 +102,19 @@ public class SpecificItemController {
             @RequestParam(required = false) String rangeEnd,
             @RequestParam(required = false, defaultValue = "false") boolean showSavedOnly,
             @RequestParam(required = false, defaultValue = "false") boolean grouped
-    ) {
+    ) throws java.io.IOException {
         Map<String, Object> params = buildParams(
                 dataType, demandAgencyName, demandAgencyRegion, vendorBizRegNo,
                 itemCategoryNo, detailItemNo, isMas, isExcellentProduct,
                 year, month, rangeStart, rangeEnd, showSavedOnly, grouped, 0, Integer.MAX_VALUE);
 
-        org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody body =
-                out -> writeExcel(out, params, grouped);
+        java.io.ByteArrayOutputStream out = new java.io.ByteArrayOutputStream();
+        writeExcel(out, params, grouped);
 
         return ResponseEntity.ok()
                 .header("Content-Disposition", "attachment; filename=\"specific_item.xlsx\"")
                 .header("Content-Type", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")
-                .body(body);
+                .body(out.toByteArray());
     }
 
     private Map<String, Object> buildParams(


### PR DESCRIPTION
## 문제
엑셀 다운로드가 브라우저에서 "다운로드에 실패했습니다" — 서버 로그에 `AccessDeniedException` + "response is already committed".

## 원인
직전 변경에서 도입한 `StreamingResponseBody`는 별도 비동기 스레드에서 실행되고, 완료 후 Spring MVC가 ASYNC 재디스패치를 수행. stateless JWT 인증 필터는 `OncePerRequestFilter` 기본값상 async 디스패치에는 재실행되지 않아 SecurityContext가 비어 `AccessDenied` 발생. (curl은 Authorization 헤더로 통과해 재현 안 됨)

## 조치
- 비동기 `StreamingResponseBody` 제거 → 요청 스레드에서 동기로 생성해 `byte[]` 반환
- SXSSFWorkbook(윈도우 100) + MyBatis Cursor 스트리밍은 유지 → 메모리 낮게 유지(OOM 방지)

## 검증 (로컬)
- 우수제품만: 200, 24MB, 13s, xlsx 유효
- 묶어서: 200, 37MB, 18s, xlsx 유효
- AccessDenied/OOM 0건

🔗 G2B-19

🤖 Generated with [Claude Code](https://claude.com/claude-code)