### PR TITLE
G2B-20 feat: 특정품목 통합 페이지 컬럼/요약/표시 개선

### DIFF
--- a/backend/src/main/java/org/example/g2bplatform/controller/SpecificItemController.java
+++ b/backend/src/main/java/org/example/g2bplatform/controller/SpecificItemController.java
@@ -66,6 +66,10 @@ public class SpecificItemController {
         Map<String, Object> res = new HashMap<>();
         res.put("data", data);
         res.put("recordsFiltered", total);
+        if (grouped) {
+            // 묶어서 보기 상단 합계 (최초/최종 계약금액)
+            res.put("totals", specificItemMapper.selectGroupedTotals(params));
+        }
         return ResponseEntity.ok(res);
     }
 
@@ -152,8 +156,8 @@ public class SpecificItemController {
         try {
             org.apache.poi.ss.usermodel.Sheet sheet = wb.createSheet("특정품목");
             String[] headers = grouped
-                    ? new String[]{"구분","업체명","사업자번호","수요기관명","수요기관지역","계약유형","물품분류번호","세부품명","최초계약일자","최종계약일자","최종계약금액(합계)","계약건수","장기여부","저장"}
-                    : new String[]{"구분","업체명","사업자번호","수요기관명","수요기관지역","계약방법","계약유형","물품분류번호","세부품명번호","세부품명","물품식별명","단위","단가","수량","공급금액","MAS","우수제품","직접구매","중기간경쟁","최초계약일자","계약일자","장기여부","저장"};
+                    ? new String[]{"구분","업체명","사업자번호","수요기관명","수요기관지역","계약명","계약방법","계약유형","MAS","물품분류번호","물품분류명","최초계약일자","최종계약일자","최초계약금액","최종계약금액(합계)","계약건수","장기여부","저장"}
+                    : new String[]{"구분","업체명","사업자번호","수요기관명","수요기관지역","계약명","계약방법","계약유형","물품분류번호","물품분류명","세부품명번호","세부품명","물품식별명","단위","단가","수량","공급금액","MAS","우수제품","직접구매","중기간경쟁","최초계약일자","계약일자","장기여부","저장"};
 
             org.apache.poi.ss.usermodel.Row header = sheet.createRow(0);
             for (int i = 0; i < headers.length; i++) header.createCell(i).setCellValue(headers[i]);
@@ -185,15 +189,19 @@ public class SpecificItemController {
         setCell(row, 2, r.get("vendorBizRegNo"));
         setCell(row, 3, r.get("demandAgencyName"));
         setCell(row, 4, r.get("demandAgencyRegion"));
-        setCell(row, 5, r.get("contractType"));
-        setCell(row, 6, r.get("itemCategoryNo"));
-        setCell(row, 7, r.get("detailItemName"));
-        setCell(row, 8, r.get("firstContractDate"));
-        setCell(row, 9, r.get("lastContractDate"));
-        setCell(row, 10, r.get("totalSupplyAmount"));
-        setCell(row, 11, r.get("contractCount"));
-        setCell(row, 12, r.get("isLongTerm"));
-        setCell(row, 13, r.get("saved"));
+        setCell(row, 5, r.get("contractName"));
+        setCell(row, 6, r.get("contractMethod"));
+        setCell(row, 7, r.get("contractType"));
+        setCell(row, 8, r.get("isMas"));
+        setCell(row, 9, r.get("itemCategoryNo"));
+        setCell(row, 10, r.get("itemCategoryName"));
+        setCell(row, 11, r.get("firstContractDate"));
+        setCell(row, 12, r.get("lastContractDate"));
+        setCell(row, 13, r.get("initialContractAmount"));
+        setCell(row, 14, r.get("totalSupplyAmount"));
+        setCell(row, 15, r.get("contractCount"));
+        setCell(row, 16, r.get("isLongTerm"));
+        setCell(row, 17, r.get("saved"));
     }
 
     private void writeFlatRow(org.apache.poi.ss.usermodel.Row row, Map<String, Object> r) {
@@ -202,24 +210,26 @@ public class SpecificItemController {
         setCell(row, 2, r.get("vendorBizRegNo"));
         setCell(row, 3, r.get("demandAgencyName"));
         setCell(row, 4, r.get("demandAgencyRegion"));
-        setCell(row, 5, r.get("contractMethod"));
-        setCell(row, 6, r.get("contractType"));
-        setCell(row, 7, r.get("itemCategoryNo"));
-        setCell(row, 8, r.get("detailItemNo"));
-        setCell(row, 9, r.get("detailItemName"));
-        setCell(row, 10, r.get("itemIdentifierName"));
-        setCell(row, 11, r.get("unit"));
-        setCell(row, 12, r.get("unitPrice"));
-        setCell(row, 13, r.get("quantity"));
-        setCell(row, 14, r.get("supplyAmount"));
-        setCell(row, 15, r.get("isMas"));
-        setCell(row, 16, r.get("isExcellentProduct"));
-        setCell(row, 17, r.get("isDirectPurchase"));
-        setCell(row, 18, r.get("isSmeCompetitive"));
-        setCell(row, 19, r.get("firstContractDate"));
-        setCell(row, 20, r.get("contractDate"));
-        setCell(row, 21, r.get("isLongTerm"));
-        setCell(row, 22, r.get("saved"));
+        setCell(row, 5, r.get("contractName"));
+        setCell(row, 6, r.get("contractMethod"));
+        setCell(row, 7, r.get("contractType"));
+        setCell(row, 8, r.get("itemCategoryNo"));
+        setCell(row, 9, r.get("itemCategoryName"));
+        setCell(row, 10, r.get("detailItemNo"));
+        setCell(row, 11, r.get("detailItemName"));
+        setCell(row, 12, r.get("itemIdentifierName"));
+        setCell(row, 13, r.get("unit"));
+        setCell(row, 14, r.get("unitPrice"));
+        setCell(row, 15, r.get("quantity"));
+        setCell(row, 16, r.get("supplyAmount"));
+        setCell(row, 17, r.get("isMas"));
+        setCell(row, 18, r.get("isExcellentProduct"));
+        setCell(row, 19, r.get("isDirectPurchase"));
+        setCell(row, 20, r.get("isSmeCompetitive"));
+        setCell(row, 21, r.get("firstContractDate"));
+        setCell(row, 22, r.get("contractDate"));
+        setCell(row, 23, r.get("isLongTerm"));
+        setCell(row, 24, r.get("saved"));
     }
 
     private void setCell(org.apache.poi.ss.usermodel.Row row, int col, Object val) {

--- a/backend/src/main/java/org/example/g2bplatform/mapper/SpecificItemMapper.java
+++ b/backend/src/main/java/org/example/g2bplatform/mapper/SpecificItemMapper.java
@@ -21,6 +21,9 @@ public interface SpecificItemMapper {
 
     int selectGroupedCount(@Param("p") Map<String, Object> params);
 
+    /** 묶어서 보기 상단 합계 (최초/최종 계약금액 합계) */
+    Map<String, Object> selectGroupedTotals(@Param("p") Map<String, Object> params);
+
     /** 엑셀 export 전용 — 전체 행을 스트리밍으로 반환 */
     Cursor<Map<String, Object>> selectGroupedListExport(@Param("p") Map<String, Object> params);
 

--- a/backend/src/main/java/org/example/g2bplatform/service/SpecificItemEtlService.java
+++ b/backend/src/main/java/org/example/g2bplatform/service/SpecificItemEtlService.java
@@ -162,12 +162,14 @@ public class SpecificItemEtlService {
 
         // 2) 재집계
         jdbc.update("TRUNCATE TABLE specific_item_grouped");
+        // 날짜·금액 기준은 contract_date(최종 변경 반영 계약일)로 통일.
+        // 최초계약금액 = 그룹 내 가장 이른 contract_date 건들의 supply_amount 합 (윈도우로 grp_min_date 산출).
         int grouped = jdbc.update(
                 "INSERT INTO specific_item_grouped (" +
                 "  data_type, group_key, vendor_biz_reg_no, first_year_contract_no, contract_no," +
-                "  vendor_name, demand_agency_name, demand_agency_region, contract_method, contract_type," +
-                "  item_category_no, detail_item_name, is_long_term," +
-                "  first_contract_date, last_contract_date, total_supply_amount, contract_count, saved" +
+                "  vendor_name, demand_agency_name, demand_agency_region, contract_name, contract_method, contract_type, is_mas," +
+                "  item_category_no, item_category_name, detail_item_name, is_long_term," +
+                "  first_contract_date, last_contract_date, total_supply_amount, initial_contract_amount, contract_count, saved" +
                 ") SELECT" +
                 "  data_type," +
                 "  COALESCE(first_year_contract_no, contract_no) AS group_key," +
@@ -177,18 +179,25 @@ public class SpecificItemEtlService {
                 "  MAX(vendor_name)," +
                 "  MAX(demand_agency_name)," +
                 "  MIN(demand_agency_region)," +
+                "  MAX(contract_name)," +
                 "  MAX(contract_method)," +
                 "  MAX(contract_type)," +
+                "  MAX(is_mas)," +
                 "  MAX(item_category_no)," +
+                "  MAX(item_category_name)," +
                 "  MAX(detail_item_name)," +
                 "  MAX(is_long_term)," +
-                "  MIN(first_contract_date)," +
-                "  MAX(contract_date)," +
-                "  SUM(COALESCE(supply_amount, 0))," +
+                "  MIN(contract_date)," +                  // 최초계약일자 = 가장 이른 계약일자
+                "  MAX(contract_date)," +                  // 최종계약일자
+                "  SUM(COALESCE(supply_amount, 0))," +     // 최종계약금액 합계
+                "  SUM(CASE WHEN contract_date = grp_min_date THEN COALESCE(supply_amount,0) ELSE 0 END)," + // 최초계약금액
                 "  COUNT(DISTINCT contract_no)," +
                 "  'N'" +
-                " FROM specific_item_flat" +
-                " WHERE is_active = 'Y'" +
+                " FROM (" +
+                "   SELECT *," +
+                "     MIN(contract_date) OVER (PARTITION BY data_type, COALESCE(first_year_contract_no, contract_no), vendor_biz_reg_no) AS grp_min_date" +
+                "   FROM specific_item_flat WHERE is_active = 'Y'" +
+                " ) t" +
                 " GROUP BY data_type, COALESCE(first_year_contract_no, contract_no), vendor_biz_reg_no");
 
         // 3) saved 복원 — 백업한 키 기준 batch UPDATE (NULL-safe <=>)

--- a/backend/src/main/resources/db/migration/V17__add_specific_item_grouped_columns.sql
+++ b/backend/src/main/resources/db/migration/V17__add_specific_item_grouped_columns.sql
@@ -1,0 +1,10 @@
+-- 특정품목 grouped 표시 항목 보강
+-- - contract_name      : 계약명 (요구 1)
+-- - is_mas             : MAS여부 (요구 2, MAS/3자단가 구분)
+-- - item_category_name : 물품분류명 (요구 5, 세부품명 대신 표시)
+-- - initial_contract_amount : 최초계약금액 (요구 4, 그룹 내 가장 이른 contract_date 건들의 금액 합)
+ALTER TABLE specific_item_grouped
+    ADD COLUMN contract_name           VARCHAR(500) DEFAULT NULL COMMENT '계약명'         AFTER demand_agency_region,
+    ADD COLUMN is_mas                  CHAR(1)      DEFAULT NULL COMMENT 'MAS여부 Y/N'    AFTER contract_type,
+    ADD COLUMN item_category_name      VARCHAR(100) DEFAULT NULL COMMENT '물품분류명'      AFTER item_category_no,
+    ADD COLUMN initial_contract_amount BIGINT NOT NULL DEFAULT 0 COMMENT '최초계약금액(가장 이른 contract_date 건 합)' AFTER total_supply_amount;

--- a/backend/src/main/resources/org/example/g2bplatform/mapper/SpecificItemMapper.xml
+++ b/backend/src/main/resources/org/example/g2bplatform/mapper/SpecificItemMapper.xml
@@ -113,9 +113,11 @@
             vendor_biz_reg_no                                   AS vendorBizRegNo,
             demand_agency_name                                  AS demandAgencyName,
             demand_agency_region                                AS demandAgencyRegion,
+            contract_name                                       AS contractName,
             contract_method                                     AS contractMethod,
             contract_type                                       AS contractType,
             item_category_no                                    AS itemCategoryNo,
+            item_category_name                                  AS itemCategoryName,
             detail_item_no                                      AS detailItemNo,
             detail_item_name                                    AS detailItemName,
             item_identifier_name                                AS itemIdentifierName,
@@ -184,13 +186,17 @@
             vendor_biz_reg_no                                   AS vendorBizRegNo,
             demand_agency_name                                  AS demandAgencyName,
             demand_agency_region                                AS demandAgencyRegion,
+            contract_name                                       AS contractName,
             contract_method                                     AS contractMethod,
             contract_type                                       AS contractType,
+            is_mas                                              AS isMas,
             item_category_no                                    AS itemCategoryNo,
+            item_category_name                                  AS itemCategoryName,
             detail_item_name                                    AS detailItemName,
             is_long_term                                        AS isLongTerm,
             DATE_FORMAT(first_contract_date, '%Y-%m-%d')        AS firstContractDate,
             DATE_FORMAT(last_contract_date, '%Y-%m-%d')         AS lastContractDate,
+            initial_contract_amount                             AS initialContractAmount,
             total_supply_amount                                 AS totalSupplyAmount,
             contract_count                                      AS contractCount,
             IFNULL(saved, 'N')                                  AS saved
@@ -198,6 +204,15 @@
         <include refid="groupedWhere"/>
         ORDER BY last_contract_date DESC, id
         LIMIT #{p.start}, #{p.length}
+    </select>
+
+    <!-- 묶어서 보기 상단 합계: 최초계약금액 합계 / 최종계약금액 합계 -->
+    <select id="selectGroupedTotals" resultType="map">
+        SELECT
+            COALESCE(SUM(initial_contract_amount), 0) AS initialAmountSum,
+            COALESCE(SUM(total_supply_amount), 0)     AS finalAmountSum
+        FROM specific_item_grouped
+        <include refid="groupedWhere"/>
     </select>
 
     <select id="selectGroupedCount" resultType="int">
@@ -214,11 +229,15 @@
             vendor_biz_reg_no                                   AS vendorBizRegNo,
             demand_agency_name                                  AS demandAgencyName,
             demand_agency_region                                AS demandAgencyRegion,
+            contract_name                                       AS contractName,
+            contract_method                                     AS contractMethod,
             contract_type                                       AS contractType,
+            is_mas                                              AS isMas,
             item_category_no                                    AS itemCategoryNo,
-            detail_item_name                                    AS detailItemName,
+            item_category_name                                  AS itemCategoryName,
             DATE_FORMAT(first_contract_date, '%Y-%m-%d')        AS firstContractDate,
             DATE_FORMAT(last_contract_date, '%Y-%m-%d')         AS lastContractDate,
+            initial_contract_amount                             AS initialContractAmount,
             total_supply_amount                                 AS totalSupplyAmount,
             contract_count                                      AS contractCount,
             is_long_term                                        AS isLongTerm,

--- a/docs/adr/ADR-0003-specific-item-grouped-and-display.md
+++ b/docs/adr/ADR-0003-specific-item-grouped-and-display.md
@@ -1,0 +1,68 @@
+# ADR-0003: 특정품목 통합 grouped 집계 및 통합 조회 화면 표시 기준
+
+- 상태: 채택(Accepted)
+- 작성일: 2026-06-17
+- 관련 티켓: G2B-16, G2B-20
+- 관련 코드:
+  - `backend/.../service/SpecificItemEtlService.java` (`rebuildGrouped`)
+  - `backend/.../mapper/SpecificItemMapper.xml`
+  - `backend/src/main/resources/db/migration/V14`, `V17`
+  - `frontend/src/views/ReportSpecificItemView.vue`
+
+## 배경
+
+특정품목 조달내역(물품·쇼핑몰)을 단일 화면에서 조회하는 통합 페이지를 운영한다.
+조회 성능과 "장기계약 묶어서 보기", 저장(saved) 독립 관리를 위해
+`specific_item_flat`(상세) → `specific_item_grouped`(집계) 2단계 구조를 사용한다.
+본 ADR은 grouped 집계 기준과 화면 표시 항목의 결정 사항을 기록한다.
+
+## 결정
+
+### 1) 물품 / 쇼핑몰 구분
+- `contract_type='제3자단가계약' AND delivery_contract_type='납품'` → `shopping_mall`
+- 그 외 전부 → `general`
+- ETL(`toParams`)에서 `data_type`으로 산출한다.
+
+### 2) 장기계약 묶음(grouped) 기준
+- 묶음 키 = `data_type` + `COALESCE(first_year_contract_no, contract_no)` + `vendor_biz_reg_no`
+- 초년도계약번호(`first_year_contract_no`)가 있으면 그 값으로, 없으면 자기 `contract_no`로 묶인다.
+  - 장기계속계약: 같은 초년도계약번호의 연차 계약들이 1행으로 병합
+  - 단기·단일계약: 개별 1행
+- 장기 판정 플래그(`is_long_term`)는 **묶음 기준이 아니며**, `new_long_term_type` ∈ {신규(장기), 장기, 계속비} 일 때 'Y'로 화면 배지 표시용으로만 쓴다.
+
+### 3) flat 적재 범위
+- `business_type='물품' AND is_final_contract='Y'` 인 행만 flat에 적재(증분, `INSERT IGNORE`).
+- 즉 계약별 **최종 변경분 1행(+품목별 item_seq)** 만 보관한다.
+
+### 4) 날짜·금액 기준은 contract_date로 통일
+변경계약이 있는 경우 원계약일(`first_contract_date`)은 의미가 약하므로,
+grouped의 날짜·금액 산출은 모두 `contract_date`(최종 변경 반영 계약일) 기준으로 한다.
+
+- 최초계약일자 = `MIN(contract_date)` (그룹 내 가장 이른 계약일)
+- 최종계약일자 = `MAX(contract_date)`
+- 최초계약금액 = `SUM(supply_amount WHERE contract_date = MIN(contract_date))`
+  (그룹에서 가장 이른 계약일 건들의 공급금액 합 = 장기계약의 첫 연차 금액)
+- 최종계약금액 합계 = `SUM(supply_amount)` (그룹 전체 합)
+
+이는 기존 `procurement_contract_grouped`를 채우는 `sp_etl_procurement_contracts`의
+`initial_contract_amount`/`final_contract_amount_sum` 산출 방식과 동일하다.
+
+### 5) 화면 표시 항목 (G2B-20)
+- 계약명(`contract_name`) 컬럼 추가 (flat·grouped)
+- MAS/3자단가 구분: `is_mas`(다수공급자계약 여부) 컬럼 노출
+- 표시 품명: 세부품명 대신 **물품분류명**(`item_category_name`, 100% 적재)으로 변경
+- 묶어서 보기 상단에 최초/최종 계약금액 합계 표기(`selectGroupedTotals`)
+- 입찰공고번호는 원천(특정품목 조달내역 CSV)에 존재하지 않아 미표시
+  (현 `bid_notice_no` 컬럼은 실제로 `base_contract_no`(계약번호)를 담고 있어 추후 정리 대상)
+
+## 대안 및 기각 사유
+- **DB View로 grouped 처리**: 실시간 GROUP BY라 대용량(45만 그룹)에서 조회가 155초까지 느려지고,
+  묶음 단위 saved 저장 컬럼을 둘 수 없어 기각. 물리 테이블 + ETL 집계 채택.
+- **최초계약금액을 변경 0차 금액으로 산출**: 특정품목 CSV에 최초계약금액 컬럼이 없고,
+  flat은 최종행만 보관하며 일부 계약은 raw에도 초기 차수가 누락되어 복원 불가. 기각.
+  → 그룹 내 "가장 이른 contract_date 건 금액"을 최초계약금액으로 정의.
+
+## 영향
+- V17 마이그레이션으로 grouped에 `contract_name`, `is_mas`, `item_category_name`, `initial_contract_amount` 추가.
+- ETL `rebuildGrouped`는 매 실행 시 grouped를 TRUNCATE 후 재집계하며 saved는 보존한다.
+- CSV 업로드 → raw → flat → grouped까지 자동 파이프라인으로 처리된다.

--- a/frontend/src/views/ReportSpecificItemView.vue
+++ b/frontend/src/views/ReportSpecificItemView.vue
@@ -83,6 +83,13 @@
       </div>
     </div>
 
+    <!-- 묶어서 보기 상단 합계 -->
+    <div v-if="grouped && totals" class="grouped-totals">
+      <span class="total-item">최초계약금액 합계 <strong>{{ formatNumber(totals.initialAmountSum) }}원</strong></span>
+      <span class="total-sep">|</span>
+      <span class="total-item">최종계약금액 합계 <strong>{{ formatNumber(totals.finalAmountSum) }}원</strong></span>
+    </div>
+
     <!-- 데이터 테이블 -->
     <div class="table-container">
       <div class="table-wrapper">
@@ -95,12 +102,15 @@
               <th>사업자번호</th>
               <th>수요기관명</th>
               <th>수요기관지역</th>
+              <th>계약명</th>
               <th>계약방법</th>
               <th>계약유형</th>
+              <th>MAS</th>
               <th>물품분류번호</th>
-              <th>세부품명</th>
+              <th>물품분류명</th>
               <th>최초계약일자</th>
               <th>최종계약일자</th>
+              <th>최초계약금액</th>
               <th>최종계약금액(합계)</th>
               <th>계약건수</th>
               <th>장기여부</th>
@@ -113,9 +123,11 @@
               <th>사업자번호</th>
               <th>수요기관명</th>
               <th>수요기관지역</th>
+              <th>계약명</th>
               <th>계약방법</th>
               <th>계약유형</th>
               <th>물품분류번호</th>
+              <th>물품분류명</th>
               <th>세부품명번호</th>
               <th>세부품명</th>
               <th>물품식별명</th>
@@ -135,10 +147,10 @@
           </thead>
           <tbody>
             <tr v-if="isLoading">
-              <td :colspan="grouped ? 15 : 23" class="loading-text">데이터를 불러오는 중입니다...</td>
+              <td :colspan="grouped ? 18 : 25" class="loading-text">데이터를 불러오는 중입니다...</td>
             </tr>
             <tr v-else-if="items.length === 0">
-              <td :colspan="grouped ? 15 : 23" class="no-data">데이터가 없습니다.</td>
+              <td :colspan="grouped ? 18 : 25" class="no-data">데이터가 없습니다.</td>
             </tr>
 
             <!-- 합쳐서 보기 행 -->
@@ -153,12 +165,15 @@
                 <td>{{ item.vendorBizRegNo }}</td>
                 <td>{{ item.demandAgencyName }}</td>
                 <td>{{ item.demandAgencyRegion }}</td>
+                <td>{{ item.contractName }}</td>
                 <td>{{ item.contractMethod }}</td>
                 <td>{{ item.contractType }}</td>
+                <td>{{ item.isMas }}</td>
                 <td>{{ item.itemCategoryNo }}</td>
-                <td>{{ item.detailItemName }}</td>
+                <td>{{ item.itemCategoryName }}</td>
                 <td>{{ item.firstContractDate }}</td>
                 <td>{{ item.lastContractDate }}</td>
+                <td>{{ formatNumber(item.initialContractAmount) }}</td>
                 <td>{{ formatNumber(item.totalSupplyAmount) }}</td>
                 <td>{{ item.contractCount }}</td>
                 <td>{{ item.isLongTerm === 'Y' ? 'Y' : 'N' }}</td>
@@ -180,9 +195,11 @@
                 <td>{{ item.vendorBizRegNo }}</td>
                 <td>{{ item.demandAgencyName }}</td>
                 <td>{{ item.demandAgencyRegion }}</td>
+                <td>{{ item.contractName }}</td>
                 <td>{{ item.contractMethod }}</td>
                 <td>{{ item.contractType }}</td>
                 <td>{{ item.itemCategoryNo }}</td>
+                <td>{{ item.itemCategoryName }}</td>
                 <td>{{ item.detailItemNo }}</td>
                 <td>{{ item.detailItemName }}</td>
                 <td>{{ item.itemIdentifierName }}</td>
@@ -238,6 +255,7 @@ const items = ref([])
 const recordsFiltered = ref(0)
 const currentPage = ref(1)
 const grouped = ref(false)
+const totals = ref(null)
 
 function onToggleClick() {
   grouped.value = !grouped.value
@@ -319,10 +337,12 @@ const fetchData = async (resetPage = false) => {
     const { data } = await axios.get(API_BASE, { params: buildParams(true) })
     items.value = Array.isArray(data.data) ? data.data : []
     recordsFiltered.value = data.recordsFiltered ?? items.value.length
+    totals.value = grouped.value && data.totals ? data.totals : null
   } catch (e) {
     console.error('특정품목 조회 실패', e)
     items.value = []
     recordsFiltered.value = 0
+    totals.value = null
   } finally {
     isLoading.value = false
   }
@@ -624,10 +644,16 @@ input[type='month']:focus {
 }
 .data-table th,
 .data-table td {
-  padding: 12px 10px;
+  padding: 6px 8px;
   border: 1px solid #e2e8f0;
   text-align: center;
-  font-size: 0.9em;
+  font-size: 0.82em;
+}
+/* 요구 3: 컬럼 폭 압축 — 긴 텍스트는 말줄임 처리해 한 화면에 최대한 표시 */
+.data-table td {
+  max-width: 180px;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 .data-table th {
   background: #f1f5f9;
@@ -649,11 +675,41 @@ input[type='month']:focus {
 }
 .table-wrapper {
   max-height: 70vh;
-  overflow: auto;
+  overflow: scroll; /* 요구 6: 상하·좌우 스크롤바 상시 표시 */
   border: 1px solid #e2e8f0;
   border-radius: 10px;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
+  scrollbar-width: auto; /* Firefox: 항상 표시 */
 }
+/* 요구 6: WebKit(Chrome/Safari) 스크롤바 상시 표시 */
+.table-wrapper::-webkit-scrollbar {
+  -webkit-appearance: none;
+  width: 12px;
+  height: 12px;
+}
+.table-wrapper::-webkit-scrollbar-thumb {
+  background: #b0b8c4;
+  border-radius: 6px;
+  border: 2px solid #f1f5f9;
+}
+.table-wrapper::-webkit-scrollbar-track {
+  background: #f1f5f9;
+}
+/* 요구 4: 묶어서 보기 상단 합계 밴드 */
+.grouped-totals {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  margin: 8px 0 4px;
+  padding: 10px 14px;
+  background: #eef2f7;
+  border: 1px solid #d6dee8;
+  border-radius: 8px;
+  font-size: 0.92em;
+  color: #334155;
+}
+.grouped-totals strong { color: #1d4ed8; margin-left: 4px; }
+.grouped-totals .total-sep { color: #94a3b8; }
 .data-table th {
   position: sticky;
   top: 0;


### PR DESCRIPTION
## 변경 사항 (요구 6건)
1. 계약명 컬럼 추가 (풀어서/묶어서 보기)
2. MAS여부 컬럼 노출 → MAS/3자단가 구분
3. 전체 컬럼 압축 표시 (폭/말줄임)
4. 묶어서 보기: 최초계약금액 컬럼 + 상단 최초/최종 계약금액 합계 밴드
5. 세부품명 → 물품분류명 표시
6. 상하·좌우 스크롤바 상시 표시

## 4번 정의 (contract_date 기준 통일)
- 최초계약일자 = MIN(contract_date), 최종계약일자 = MAX(contract_date)
- 최초계약금액 = SUM(supply_amount WHERE contract_date = MIN(contract_date))
- 최종계약금액 합계 = SUM(supply_amount)
- 기존 procurement_contract_grouped(sp_etl_procurement_contracts)와 동일 방식

## 변경 구성
- V17: specific_item_grouped에 contract_name/is_mas/item_category_name/initial_contract_amount 추가
- ETL rebuildGrouped 집계 수정 (윈도우로 그룹 최소 계약일 산출)
- Mapper: grouped 조회 신규 컬럼 + selectGroupedTotals(합계) + export 반영
- Controller: 묶어서 보기 응답 totals 추가, 엑셀 헤더/행 갱신
- 프론트: 컬럼/합계밴드/CSS
- ADR-0003

## 검증 (로컬)
- 충북1지구: 최초 16.9억 / 최종 합 30.3억, 계약명·물품분류명·MAS 정상
- 화면: 풀어서/묶어서 헤더, 합계밴드(최초 17.97조/최종 18.40조) 확인

🔗 G2B-20

🤖 Generated with [Claude Code](https://claude.com/claude-code)