### PR TITLE
G2B-21 feat: 자사 우수제품(물품분류 기준) 구분 추가

### DIFF
--- a/backend/src/main/java/org/example/g2bplatform/controller/SpecificItemController.java
+++ b/backend/src/main/java/org/example/g2bplatform/controller/SpecificItemController.java
@@ -47,6 +47,7 @@ public class SpecificItemController {
             @RequestParam(required = false) String rangeStart,
             @RequestParam(required = false) String rangeEnd,
             @RequestParam(required = false, defaultValue = "false") boolean showSavedOnly,
+            @RequestParam(required = false, defaultValue = "false") boolean topExcellentOnly,
             @RequestParam(required = false, defaultValue = "false") boolean grouped,
             @RequestParam(defaultValue = "0") int start,
             @RequestParam(defaultValue = "100") int length
@@ -54,7 +55,7 @@ public class SpecificItemController {
         Map<String, Object> params = buildParams(
                 dataType, demandAgencyName, demandAgencyRegion, vendorBizRegNo,
                 itemCategoryNo, detailItemNo, isMas, isExcellentProduct,
-                year, month, rangeStart, rangeEnd, showSavedOnly, grouped, start, length);
+                year, month, rangeStart, rangeEnd, showSavedOnly, topExcellentOnly, grouped, start, length);
 
         List<Map<String, Object>> data = grouped
                 ? specificItemMapper.selectGroupedList(params)
@@ -105,12 +106,13 @@ public class SpecificItemController {
             @RequestParam(required = false) String rangeStart,
             @RequestParam(required = false) String rangeEnd,
             @RequestParam(required = false, defaultValue = "false") boolean showSavedOnly,
+            @RequestParam(required = false, defaultValue = "false") boolean topExcellentOnly,
             @RequestParam(required = false, defaultValue = "false") boolean grouped
     ) throws java.io.IOException {
         Map<String, Object> params = buildParams(
                 dataType, demandAgencyName, demandAgencyRegion, vendorBizRegNo,
                 itemCategoryNo, detailItemNo, isMas, isExcellentProduct,
-                year, month, rangeStart, rangeEnd, showSavedOnly, grouped, 0, Integer.MAX_VALUE);
+                year, month, rangeStart, rangeEnd, showSavedOnly, topExcellentOnly, grouped, 0, Integer.MAX_VALUE);
 
         java.io.ByteArrayOutputStream out = new java.io.ByteArrayOutputStream();
         writeExcel(out, params, grouped);
@@ -126,7 +128,7 @@ public class SpecificItemController {
             String vendorBizRegNo, String itemCategoryNo, String detailItemNo,
             String isMas, String isExcellentProduct,
             Integer year, String month, String rangeStart, String rangeEnd,
-            boolean showSavedOnly, boolean grouped, int start, int length) {
+            boolean showSavedOnly, boolean topExcellentOnly, boolean grouped, int start, int length) {
 
         Map<String, Object> p = new HashMap<>();
         if (ne(dataType))          p.put("dataType", dataType);
@@ -142,6 +144,7 @@ public class SpecificItemController {
         if (ne(rangeStart))        p.put("rangeStart", rangeStart);
         if (ne(rangeEnd))          p.put("rangeEnd", rangeEnd);
         p.put("showSavedOnly", showSavedOnly);
+        p.put("topExcellentOnly", topExcellentOnly);
         p.put("start", start);
         p.put("length", length);
         return p;
@@ -156,8 +159,8 @@ public class SpecificItemController {
         try {
             org.apache.poi.ss.usermodel.Sheet sheet = wb.createSheet("특정품목");
             String[] headers = grouped
-                    ? new String[]{"구분","업체명","사업자번호","수요기관명","수요기관지역","계약명","계약방법","계약유형","MAS","물품분류번호","물품분류명","최초계약일자","최종계약일자","최초계약금액","최종계약금액(합계)","계약건수","장기여부","저장"}
-                    : new String[]{"구분","업체명","사업자번호","수요기관명","수요기관지역","계약명","계약방법","계약유형","물품분류번호","물품분류명","세부품명번호","세부품명","물품식별명","단위","단가","수량","공급금액","MAS","우수제품","직접구매","중기간경쟁","최초계약일자","계약일자","장기여부","저장"};
+                    ? new String[]{"구분","업체명","사업자번호","수요기관명","수요기관지역","계약명","계약방법","계약유형","MAS","물품분류번호","물품분류명","자사우수제품","최초계약일자","최종계약일자","최초계약금액","최종계약금액(합계)","계약건수","장기여부","저장"}
+                    : new String[]{"구분","업체명","사업자번호","수요기관명","수요기관지역","계약명","계약방법","계약유형","물품분류번호","물품분류명","세부품명번호","세부품명","물품식별명","단위","단가","수량","공급금액","MAS","우수제품","자사우수제품","직접구매","중기간경쟁","최초계약일자","계약일자","장기여부","저장"};
 
             org.apache.poi.ss.usermodel.Row header = sheet.createRow(0);
             for (int i = 0; i < headers.length; i++) header.createCell(i).setCellValue(headers[i]);
@@ -195,13 +198,14 @@ public class SpecificItemController {
         setCell(row, 8, r.get("isMas"));
         setCell(row, 9, r.get("itemCategoryNo"));
         setCell(row, 10, r.get("itemCategoryName"));
-        setCell(row, 11, r.get("firstContractDate"));
-        setCell(row, 12, r.get("lastContractDate"));
-        setCell(row, 13, r.get("initialContractAmount"));
-        setCell(row, 14, r.get("totalSupplyAmount"));
-        setCell(row, 15, r.get("contractCount"));
-        setCell(row, 16, r.get("isLongTerm"));
-        setCell(row, 17, r.get("saved"));
+        setCell(row, 11, r.get("isTopExcellent"));
+        setCell(row, 12, r.get("firstContractDate"));
+        setCell(row, 13, r.get("lastContractDate"));
+        setCell(row, 14, r.get("initialContractAmount"));
+        setCell(row, 15, r.get("totalSupplyAmount"));
+        setCell(row, 16, r.get("contractCount"));
+        setCell(row, 17, r.get("isLongTerm"));
+        setCell(row, 18, r.get("saved"));
     }
 
     private void writeFlatRow(org.apache.poi.ss.usermodel.Row row, Map<String, Object> r) {
@@ -224,12 +228,13 @@ public class SpecificItemController {
         setCell(row, 16, r.get("supplyAmount"));
         setCell(row, 17, r.get("isMas"));
         setCell(row, 18, r.get("isExcellentProduct"));
-        setCell(row, 19, r.get("isDirectPurchase"));
-        setCell(row, 20, r.get("isSmeCompetitive"));
-        setCell(row, 21, r.get("firstContractDate"));
-        setCell(row, 22, r.get("contractDate"));
-        setCell(row, 23, r.get("isLongTerm"));
-        setCell(row, 24, r.get("saved"));
+        setCell(row, 19, r.get("isTopExcellent"));
+        setCell(row, 20, r.get("isDirectPurchase"));
+        setCell(row, 21, r.get("isSmeCompetitive"));
+        setCell(row, 22, r.get("firstContractDate"));
+        setCell(row, 23, r.get("contractDate"));
+        setCell(row, 24, r.get("isLongTerm"));
+        setCell(row, 25, r.get("saved"));
     }
 
     private void setCell(org.apache.poi.ss.usermodel.Row row, int col, Object val) {

--- a/backend/src/main/resources/db/migration/V18__create_top_excellent_category.sql
+++ b/backend/src/main/resources/db/migration/V18__create_top_excellent_category.sql
@@ -1,0 +1,19 @@
+-- 자사(탑인더스트리/탑정보통신) 우수제품 기준 물품분류번호 설정 테이블
+-- 조달청 우수제품 인증(is_excellent_product)과 별개로, 지정된 물품분류번호를
+-- '자사 우수제품'으로 동적 판정한다. 목록 변경 시 재적재 없이 즉시 반영된다.
+CREATE TABLE IF NOT EXISTS top_excellent_category (
+    item_category_no    VARCHAR(10)  NOT NULL PRIMARY KEY COMMENT '물품분류번호',
+    item_category_name  VARCHAR(100)          DEFAULT NULL COMMENT '물품분류명',
+    is_active           CHAR(1)      NOT NULL DEFAULT 'Y' COMMENT '사용여부 Y/N',
+    created_at          DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+  COMMENT='자사 우수제품 기준 물품분류번호';
+
+INSERT INTO top_excellent_category (item_category_no, item_category_name) VALUES
+    ('39121101', '분전반'),
+    ('39121103', '배전반'),
+    ('39121104', '전동기제어반'),
+    ('39121189', '계장제어장치'),
+    ('39121801', '빌딩자동제어장치'),
+    ('41112498', '프로세스제어반')
+ON DUPLICATE KEY UPDATE item_category_name = VALUES(item_category_name);

--- a/backend/src/main/resources/org/example/g2bplatform/mapper/SpecificItemMapper.xml
+++ b/backend/src/main/resources/org/example/g2bplatform/mapper/SpecificItemMapper.xml
@@ -12,6 +12,12 @@
         END AS dataTypeLabel
     </sql>
 
+    <!-- 자사 우수제품 판정: 설정 테이블(top_excellent_category)에 등록된 물품분류번호면 Y -->
+    <sql id="topExcellentSelect">
+        CASE WHEN item_category_no IN (SELECT item_category_no FROM top_excellent_category WHERE is_active = 'Y')
+             THEN 'Y' ELSE 'N' END AS isTopExcellent
+    </sql>
+
     <sql id="commonWhere">
         WHERE is_active = 'Y'
         <if test="p.dataType != null">
@@ -37,6 +43,9 @@
         </if>
         <if test="p.isExcellentProduct != null">
             AND is_excellent_product = #{p.isExcellentProduct}
+        </if>
+        <if test="p.topExcellentOnly == true">
+            AND item_category_no IN (SELECT item_category_no FROM top_excellent_category WHERE is_active = 'Y')
         </if>
         <if test="p.year != null">
             AND contract_date &gt;= CONCAT(#{p.year}, '-01-01')
@@ -88,6 +97,7 @@
             supply_amount                                       AS supplyAmount,
             is_mas                                              AS isMas,
             is_excellent_product                                AS isExcellentProduct,
+            <include refid="topExcellentSelect"/>,
             is_direct_purchase                                  AS isDirectPurchase,
             is_sme_competitive                                  AS isSmeCompetitive,
             DATE_FORMAT(contract_date, '%Y-%m-%d')              AS contractDate,
@@ -127,6 +137,7 @@
             supply_amount                                       AS supplyAmount,
             is_mas                                              AS isMas,
             is_excellent_product                                AS isExcellentProduct,
+            <include refid="topExcellentSelect"/>,
             is_direct_purchase                                  AS isDirectPurchase,
             is_sme_competitive                                  AS isSmeCompetitive,
             DATE_FORMAT(first_contract_date, '%Y-%m-%d')        AS firstContractDate,
@@ -156,6 +167,9 @@
         </if>
         <if test="p.itemCategoryNo != null">
             AND item_category_no LIKE CONCAT('%', #{p.itemCategoryNo}, '%')
+        </if>
+        <if test="p.topExcellentOnly == true">
+            AND item_category_no IN (SELECT item_category_no FROM top_excellent_category WHERE is_active = 'Y')
         </if>
         <if test="p.year != null">
             AND last_contract_date &gt;= CONCAT(#{p.year}, '-01-01')
@@ -192,6 +206,7 @@
             is_mas                                              AS isMas,
             item_category_no                                    AS itemCategoryNo,
             item_category_name                                  AS itemCategoryName,
+            <include refid="topExcellentSelect"/>,
             detail_item_name                                    AS detailItemName,
             is_long_term                                        AS isLongTerm,
             DATE_FORMAT(first_contract_date, '%Y-%m-%d')        AS firstContractDate,
@@ -235,6 +250,7 @@
             is_mas                                              AS isMas,
             item_category_no                                    AS itemCategoryNo,
             item_category_name                                  AS itemCategoryName,
+            <include refid="topExcellentSelect"/>,
             DATE_FORMAT(first_contract_date, '%Y-%m-%d')        AS firstContractDate,
             DATE_FORMAT(last_contract_date, '%Y-%m-%d')         AS lastContractDate,
             initial_contract_amount                             AS initialContractAmount,

--- a/frontend/src/views/ReportSpecificItemView.vue
+++ b/frontend/src/views/ReportSpecificItemView.vue
@@ -46,6 +46,10 @@
           <input type="checkbox" v-model="filters.excellentOnly" />
           우수제품만 보기
         </label>
+        <label class="checkbox-label">
+          <input type="checkbox" v-model="filters.topExcellentOnly" />
+          자사 우수제품만 보기
+        </label>
         <span class="actions-sep" aria-hidden="true"></span>
         <div class="long-term-toggle-wrap">
           <span class="long-term-toggle-label">장기계약 건</span>
@@ -108,6 +112,7 @@
               <th>MAS</th>
               <th>물품분류번호</th>
               <th>물품분류명</th>
+              <th>자사우수제품</th>
               <th>최초계약일자</th>
               <th>최종계약일자</th>
               <th>최초계약금액</th>
@@ -137,6 +142,7 @@
               <th>공급금액</th>
               <th>MAS</th>
               <th>우수제품</th>
+              <th>자사우수제품</th>
               <th>직접구매</th>
               <th>중기간경쟁</th>
               <th>최초계약일자</th>
@@ -147,10 +153,10 @@
           </thead>
           <tbody>
             <tr v-if="isLoading">
-              <td :colspan="grouped ? 18 : 25" class="loading-text">데이터를 불러오는 중입니다...</td>
+              <td :colspan="grouped ? 19 : 26" class="loading-text">데이터를 불러오는 중입니다...</td>
             </tr>
             <tr v-else-if="items.length === 0">
-              <td :colspan="grouped ? 18 : 25" class="no-data">데이터가 없습니다.</td>
+              <td :colspan="grouped ? 19 : 26" class="no-data">데이터가 없습니다.</td>
             </tr>
 
             <!-- 합쳐서 보기 행 -->
@@ -171,6 +177,7 @@
                 <td>{{ item.isMas }}</td>
                 <td>{{ item.itemCategoryNo }}</td>
                 <td>{{ item.itemCategoryName }}</td>
+                <td>{{ item.isTopExcellent }}</td>
                 <td>{{ item.firstContractDate }}</td>
                 <td>{{ item.lastContractDate }}</td>
                 <td>{{ formatNumber(item.initialContractAmount) }}</td>
@@ -209,6 +216,7 @@
                 <td>{{ formatNumber(item.supplyAmount) }}</td>
                 <td>{{ item.isMas }}</td>
                 <td>{{ item.isExcellentProduct }}</td>
+                <td>{{ item.isTopExcellent }}</td>
                 <td>{{ item.isDirectPurchase }}</td>
                 <td>{{ item.isSmeCompetitive }}</td>
                 <td>{{ item.firstContractDate }}</td>
@@ -278,6 +286,7 @@ const filters = reactive({
   rangeEnd: '',
   showSavedOnly: false,
   excellentOnly: false,
+  topExcellentOnly: false,
 })
 
 function groupedRowKey(item) {
@@ -307,6 +316,7 @@ function buildParams(includePaging = true) {
     rangeEnd: filters.dateType === 'range' ? filters.rangeEnd || undefined : undefined,
     showSavedOnly: filters.showSavedOnly,
     isExcellentProduct: !grouped.value && filters.excellentOnly ? 'Y' : undefined,
+    topExcellentOnly: filters.topExcellentOnly || undefined,
   }
   if (includePaging) {
     p.start = (currentPage.value - 1) * PAGE_SIZE
@@ -420,6 +430,11 @@ watch(
 
 watch(
   () => filters.excellentOnly,
+  () => fetchData(true),
+)
+
+watch(
+  () => filters.topExcellentOnly,
   () => fetchData(true),
 )
 


### PR DESCRIPTION
## 요구
탑인더스트리/탑정보통신은 지정 6개 물품분류번호(분전반·배전반·전동기제어반·계장제어장치·빌딩자동제어장치·프로세스제어반)만 우수제품으로 보고자 함.

## 결정 (사용자 확인)
- 적용: 플랫폼 전체(전사 공통)
- 기존 is_excellent_product(조달청 인증) 보존 + '자사 우수제품' 별도 개념 추가
- 대상 분류번호는 DB 설정 테이블로 관리 (목록 변경 시 재적재 불필요)

## 변경
- V18: top_excellent_category 설정 테이블 + 6건 시드
- Mapper: isTopExcellent 동적 판정(설정 테이블 IN) + topExcellentOnly 필터 (flat·grouped·export)
- Controller: topExcellentOnly 파라미터, 엑셀 자사우수제품 컬럼
- 프론트: 자사우수제품 컬럼 + '자사 우수제품만 보기' 필터

## 검증 (로컬)
- 필터 ON → 6개 분류만 206,477건, isTopExcellent 모두 Y
- 화면: 체크박스/컬럼/필터 동작 확인

🔗 G2B-21

🤖 Generated with [Claude Code](https://claude.com/claude-code)