### PR TITLE
G2B-22 perf: 우수제품 체크박스 제거 및 자사 우수제품 조회 성능 개선

### DIFF
--- a/backend/src/main/java/org/example/g2bplatform/controller/SpecificItemController.java
+++ b/backend/src/main/java/org/example/g2bplatform/controller/SpecificItemController.java
@@ -145,6 +145,8 @@ public class SpecificItemController {
         if (ne(rangeEnd))          p.put("rangeEnd", rangeEnd);
         p.put("showSavedOnly", showSavedOnly);
         p.put("topExcellentOnly", topExcellentOnly);
+        // 자사 우수제품 판정/필터용 분류번호 목록 (리터럴 IN — 서브쿼리 회피로 인덱스 활용)
+        p.put("topCategories", specificItemMapper.selectTopCategories());
         p.put("start", start);
         p.put("length", length);
         return p;

--- a/backend/src/main/java/org/example/g2bplatform/mapper/SpecificItemMapper.java
+++ b/backend/src/main/java/org/example/g2bplatform/mapper/SpecificItemMapper.java
@@ -27,6 +27,9 @@ public interface SpecificItemMapper {
     /** 엑셀 export 전용 — 전체 행을 스트리밍으로 반환 */
     Cursor<Map<String, Object>> selectGroupedListExport(@Param("p") Map<String, Object> params);
 
+    /** 자사 우수제품 기준 물품분류번호 목록 (설정 테이블) */
+    List<String> selectTopCategories();
+
     void updateSaved(Map<String, Object> params);
 
     void updateGroupedSaved(Map<String, Object> params);

--- a/backend/src/main/resources/db/migration/V19__add_specific_item_flat_category_order_index.sql
+++ b/backend/src/main/resources/db/migration/V19__add_specific_item_flat_category_order_index.sql
@@ -1,0 +1,6 @@
+-- 자사 우수제품(물품분류번호 IN) 필터 조회 성능 개선
+-- 자사 우수제품 count(WHERE is_active='Y' AND item_category_no IN (...))가
+-- 기존 인덱스로 41만행을 스캔하던 것을 커버링 인덱스로 처리(약 1.58s → 0.11s).
+-- list는 idx_flat_list_order(계약일자 정렬)를 사용하며, 리터럴 IN 전달로 filesort를 제거한다.
+CREATE INDEX idx_flat_category_order
+    ON specific_item_flat (is_active, item_category_no, contract_date DESC, contract_no ASC, item_seq ASC);

--- a/backend/src/main/resources/org/example/g2bplatform/mapper/SpecificItemMapper.xml
+++ b/backend/src/main/resources/org/example/g2bplatform/mapper/SpecificItemMapper.xml
@@ -12,11 +12,23 @@
         END AS dataTypeLabel
     </sql>
 
-    <!-- 자사 우수제품 판정: 설정 테이블(top_excellent_category)에 등록된 물품분류번호면 Y -->
+    <!-- 자사 우수제품 판정: 앱에서 전달한 분류번호 목록(리터럴 IN)으로 판정 (서브쿼리 회피로 인덱스 활용) -->
     <sql id="topExcellentSelect">
-        CASE WHEN item_category_no IN (SELECT item_category_no FROM top_excellent_category WHERE is_active = 'Y')
-             THEN 'Y' ELSE 'N' END AS isTopExcellent
+        <choose>
+            <when test="p.topCategories != null and p.topCategories.size() > 0">
+                CASE WHEN item_category_no IN
+                <foreach item="c" collection="p.topCategories" open="(" separator="," close=")">#{c}</foreach>
+                THEN 'Y' ELSE 'N' END AS isTopExcellent
+            </when>
+            <otherwise>
+                'N' AS isTopExcellent
+            </otherwise>
+        </choose>
     </sql>
+
+    <select id="selectTopCategories" resultType="string">
+        SELECT item_category_no FROM top_excellent_category WHERE is_active = 'Y'
+    </select>
 
     <sql id="commonWhere">
         WHERE is_active = 'Y'
@@ -44,8 +56,9 @@
         <if test="p.isExcellentProduct != null">
             AND is_excellent_product = #{p.isExcellentProduct}
         </if>
-        <if test="p.topExcellentOnly == true">
-            AND item_category_no IN (SELECT item_category_no FROM top_excellent_category WHERE is_active = 'Y')
+        <if test="p.topExcellentOnly == true and p.topCategories != null and p.topCategories.size() > 0">
+            AND item_category_no IN
+            <foreach item="c" collection="p.topCategories" open="(" separator="," close=")">#{c}</foreach>
         </if>
         <if test="p.year != null">
             AND contract_date &gt;= CONCAT(#{p.year}, '-01-01')
@@ -168,8 +181,9 @@
         <if test="p.itemCategoryNo != null">
             AND item_category_no LIKE CONCAT('%', #{p.itemCategoryNo}, '%')
         </if>
-        <if test="p.topExcellentOnly == true">
-            AND item_category_no IN (SELECT item_category_no FROM top_excellent_category WHERE is_active = 'Y')
+        <if test="p.topExcellentOnly == true and p.topCategories != null and p.topCategories.size() > 0">
+            AND item_category_no IN
+            <foreach item="c" collection="p.topCategories" open="(" separator="," close=")">#{c}</foreach>
         </if>
         <if test="p.year != null">
             AND last_contract_date &gt;= CONCAT(#{p.year}, '-01-01')

--- a/frontend/src/views/ReportSpecificItemView.vue
+++ b/frontend/src/views/ReportSpecificItemView.vue
@@ -42,10 +42,6 @@
           <input type="checkbox" v-model="filters.showSavedOnly" />
           저장된 데이터만 보기
         </label>
-        <label v-if="!grouped" class="checkbox-label">
-          <input type="checkbox" v-model="filters.excellentOnly" />
-          우수제품만 보기
-        </label>
         <label class="checkbox-label">
           <input type="checkbox" v-model="filters.topExcellentOnly" />
           자사 우수제품만 보기
@@ -285,7 +281,6 @@ const filters = reactive({
   rangeStart: '',
   rangeEnd: '',
   showSavedOnly: false,
-  excellentOnly: false,
   topExcellentOnly: false,
 })
 
@@ -315,7 +310,6 @@ function buildParams(includePaging = true) {
     rangeStart: filters.dateType === 'range' ? filters.rangeStart || undefined : undefined,
     rangeEnd: filters.dateType === 'range' ? filters.rangeEnd || undefined : undefined,
     showSavedOnly: filters.showSavedOnly,
-    isExcellentProduct: !grouped.value && filters.excellentOnly ? 'Y' : undefined,
     topExcellentOnly: filters.topExcellentOnly || undefined,
   }
   if (includePaging) {
@@ -425,11 +419,6 @@ const formatNumber = (num) => {
 
 watch(
   () => filters.showSavedOnly,
-  () => fetchData(true),
-)
-
-watch(
-  () => filters.excellentOnly,
   () => fetchData(true),
 )
 


### PR DESCRIPTION
## 변경
1. '우수제품만 보기'(조달청 인증) 체크박스 제거 — '자사 우수제품만 보기'만 유지
2. 자사 우수제품 조회 성능 개선

## 성능 원인/해결
- 원인: topExcellentOnly가 IN(SELECT ...) 서브쿼리 → 옵티마이저 filesort 선택 (list 7.5s)
- 해결1: 분류번호 목록을 앱에서 읽어 리터럴 IN(foreach) 전달 → idx_flat_list_order 정렬 스캔 (list 0.14s)
- 해결2: V19 복합 인덱스 idx_flat_category_order → count 1.58s→0.11s

## 검증 (로컬)
- 자사 우수제품 조회 7.5s → 0.14s, 6개 분류 206,477건 정상
- 화면: '우수제품만 보기' 제거, '자사 우수제품만 보기'만 표시

🔗 G2B-22

🤖 Generated with [Claude Code](https://claude.com/claude-code)