### PR TITLE
G2B-23 feat: MAS/3자단가 계약방법 구분 필터 추가

### DIFF
--- a/backend/src/main/java/org/example/g2bplatform/controller/SpecificItemController.java
+++ b/backend/src/main/java/org/example/g2bplatform/controller/SpecificItemController.java
@@ -42,6 +42,7 @@ public class SpecificItemController {
             @RequestParam(required = false) String detailItemNo,
             @RequestParam(required = false) String isMas,
             @RequestParam(required = false) String isExcellentProduct,
+            @RequestParam(required = false) String contractKind,
             @RequestParam(required = false) Integer year,
             @RequestParam(required = false) String month,
             @RequestParam(required = false) String rangeStart,
@@ -54,7 +55,7 @@ public class SpecificItemController {
     ) {
         Map<String, Object> params = buildParams(
                 dataType, demandAgencyName, demandAgencyRegion, vendorBizRegNo,
-                itemCategoryNo, detailItemNo, isMas, isExcellentProduct,
+                itemCategoryNo, detailItemNo, isMas, isExcellentProduct, contractKind,
                 year, month, rangeStart, rangeEnd, showSavedOnly, topExcellentOnly, grouped, start, length);
 
         List<Map<String, Object>> data = grouped
@@ -101,6 +102,7 @@ public class SpecificItemController {
             @RequestParam(required = false) String detailItemNo,
             @RequestParam(required = false) String isMas,
             @RequestParam(required = false) String isExcellentProduct,
+            @RequestParam(required = false) String contractKind,
             @RequestParam(required = false) Integer year,
             @RequestParam(required = false) String month,
             @RequestParam(required = false) String rangeStart,
@@ -111,7 +113,7 @@ public class SpecificItemController {
     ) throws java.io.IOException {
         Map<String, Object> params = buildParams(
                 dataType, demandAgencyName, demandAgencyRegion, vendorBizRegNo,
-                itemCategoryNo, detailItemNo, isMas, isExcellentProduct,
+                itemCategoryNo, detailItemNo, isMas, isExcellentProduct, contractKind,
                 year, month, rangeStart, rangeEnd, showSavedOnly, topExcellentOnly, grouped, 0, Integer.MAX_VALUE);
 
         java.io.ByteArrayOutputStream out = new java.io.ByteArrayOutputStream();
@@ -126,11 +128,12 @@ public class SpecificItemController {
     private Map<String, Object> buildParams(
             String dataType, String demandAgencyName, String demandAgencyRegion,
             String vendorBizRegNo, String itemCategoryNo, String detailItemNo,
-            String isMas, String isExcellentProduct,
+            String isMas, String isExcellentProduct, String contractKind,
             Integer year, String month, String rangeStart, String rangeEnd,
             boolean showSavedOnly, boolean topExcellentOnly, boolean grouped, int start, int length) {
 
         Map<String, Object> p = new HashMap<>();
+        if (ne(contractKind))      p.put("contractKind", contractKind);
         if (ne(dataType))          p.put("dataType", dataType);
         if (ne(demandAgencyName))  p.put("demandAgencyName", demandAgencyName);
         if (ne(demandAgencyRegion))p.put("demandAgencyRegion", demandAgencyRegion);

--- a/backend/src/main/resources/org/example/g2bplatform/mapper/SpecificItemMapper.xml
+++ b/backend/src/main/resources/org/example/g2bplatform/mapper/SpecificItemMapper.xml
@@ -53,6 +53,15 @@
         <if test="p.isMas != null">
             AND is_mas = #{p.isMas}
         </if>
+        <if test="p.contractKind == 'mas'">
+            AND data_type = 'shopping_mall' AND is_mas = 'Y'
+        </if>
+        <if test="p.contractKind == 'third'">
+            AND data_type = 'shopping_mall' AND is_mas = 'N'
+        </if>
+        <if test="p.contractKind == 'goods'">
+            AND data_type = 'general'
+        </if>
         <if test="p.isExcellentProduct != null">
             AND is_excellent_product = #{p.isExcellentProduct}
         </if>
@@ -177,6 +186,15 @@
         </if>
         <if test="p.vendorBizRegNo != null">
             AND vendor_biz_reg_no = #{p.vendorBizRegNo}
+        </if>
+        <if test="p.contractKind == 'mas'">
+            AND data_type = 'shopping_mall' AND is_mas = 'Y'
+        </if>
+        <if test="p.contractKind == 'third'">
+            AND data_type = 'shopping_mall' AND is_mas = 'N'
+        </if>
+        <if test="p.contractKind == 'goods'">
+            AND data_type = 'general'
         </if>
         <if test="p.itemCategoryNo != null">
             AND item_category_no LIKE CONCAT('%', #{p.itemCategoryNo}, '%')

--- a/frontend/src/views/ReportSpecificItemView.vue
+++ b/frontend/src/views/ReportSpecificItemView.vue
@@ -12,6 +12,14 @@
           <option value="shopping_mall">쇼핑몰(제3자단가)</option>
         </select>
 
+        <!-- 계약방법 구분 (MAS / 3자단가 / 물품) -->
+        <select v-model="filters.contractKind" class="date-select">
+          <option value="">계약방법 전체</option>
+          <option value="mas">MAS(다수공급자계약)</option>
+          <option value="third">3자단가(일반)</option>
+          <option value="goods">물품(총액·일반단가)</option>
+        </select>
+
         <input type="text" v-model="filters.demandAgencyName" placeholder="수요기관명 검색" />
         <input type="text" v-model="filters.demandAgencyRegion" placeholder="수요기관지역 검색" />
         <input type="text" v-model="filters.vendorBizRegNo" placeholder="사업자번호 검색" />
@@ -270,6 +278,7 @@ const years = Array.from({ length: 10 }, (_, i) => String(2026 - i))
 
 const filters = reactive({
   dataType: '',
+  contractKind: '',
   demandAgencyName: '',
   demandAgencyRegion: '',
   vendorBizRegNo: '',
@@ -300,6 +309,7 @@ function buildParams(includePaging = true) {
   const p = {
     grouped: grouped.value,
     dataType: filters.dataType || undefined,
+    contractKind: filters.contractKind || undefined,
     demandAgencyName: filters.demandAgencyName || undefined,
     demandAgencyRegion: filters.demandAgencyRegion || undefined,
     vendorBizRegNo: filters.vendorBizRegNo || undefined,


### PR DESCRIPTION
## 변경
특정품목 통합 페이지에 '계약방법 구분' 드롭다운 추가 (is_mas 활용, 데이터 보강 불필요).
- MAS(다수공급자계약): shopping_mall + is_mas=Y
- 3자단가(일반): shopping_mall + is_mas=N
- 물품(총액·일반단가): general

## 검증 (로컬)
- MAS 559,699 / 3자단가 196,173 / 물품 114,881건, dataType·MAS 일치
- 화면 드롭다운 정상

🔗 G2B-23

🤖 Generated with [Claude Code](https://claude.com/claude-code)