### PR TITLE
chore: New Relic APM 라이선스 키 주입용 env_file 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ backend/sheet/*.json
 ### G2B 로컬 파일 ###
 docs/sample_csv/
 *.docx
+
+# 환경변수(비밀값) — New Relic 라이선스 키 등
+.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,10 @@ services:
             - GOOGLE_SERVICE_ACCOUNT_KEY_PATH=/app/config/top-service-account.json
             # /app/config/application.properties 를 Spring이 읽도록 지정
             - SPRING_CONFIG_ADDITIONAL_LOCATION=/app/config/
+        # New Relic APM 라이선스 키 등 비밀값 (gitignore된 .env, 서버에만 존재)
+        # New Relic Java 에이전트가 NEW_RELIC_LICENSE_KEY 환경변수를 자동 인식
+        env_file:
+            - .env
 
     web:
         build:


### PR DESCRIPTION
api 서비스에 env_file(.env) 추가 — New Relic Java 에이전트가 NEW_RELIC_LICENSE_KEY를 자동 인식. .env는 gitignore(비밀값 서버 전용).

🤖 Generated with [Claude Code](https://claude.com/claude-code)